### PR TITLE
Sync the version string across README and the settings window

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A compact, MIT-licensed macOS menu bar monitor for Bambu Lab 3D printers. BambuB
 
 ### Latest changes
 
-Version 0.1.15 adds TLS certificate pinning and two downloads: **Local** for convenient preference-based access-code storage, and **Keychain** for storage in the macOS Keychain.
+Version 0.1.18 adds **Remove printer** to the ⋯ menu on each card, finishes network scans in seconds instead of ~30 s, and makes Bambu Studio import work on a clean install.
 
 [Read the full changelog](CHANGELOG.md)
 
@@ -113,7 +113,7 @@ Kompaktowy monitor drukarek 3D Bambu Lab dla paska menu macOS, na licencji MIT. 
 
 ### Najnowsze zmiany
 
-Wersja 0.1.15 dodaje pinning certyfikatu TLS oraz dwa warianty do pobrania: **Local** — wygodne przechowywanie kodów dostępu w ustawieniach aplikacji, oraz **Keychain** — przechowywanie w pęku kluczy macOS.
+Wersja 0.1.18 dodaje **usuwanie drukarki** z menu ⋯ na karcie, skraca skanowanie sieci z ~30 s do kilku sekund oraz sprawia, że import z Bambu Studio działa na czystej instalacji.
 
 [Zobacz pełny changelog](CHANGELOG.md)
 

--- a/Sources/BambuBar/Views/SettingsWindowController.swift
+++ b/Sources/BambuBar/Views/SettingsWindowController.swift
@@ -142,7 +142,7 @@ final class SettingsWindowController: NSWindowController {
         launchLabel.stringValue = settings.text("Uruchamiaj przy logowaniu", "Launch at login")
         launchSwitch.state = LaunchAtLoginManager.isEnabled ? .on : .off
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-            ?? "0.1.17"
+            ?? "—"
         versionLabel.stringValue = settings.text("Wersja \(version)", "Version \(version)") + " • \(AccessCodeStore.modeName)"
         supportButton.title = settings.text("Wesprzyj projekt", "Support the project")
         closeButton.title = settings.text("Gotowe", "Done")


### PR DESCRIPTION
Follow-up to the docs PR #1 , which flagged this as a known hazard rather than
fixing it inline.

The version lives in four places and the 0.1.18 release moved only two:

| Location | Before | After |
| --- | --- | --- |
| `Resources/Info.plist` | 0.1.18 | 0.1.18 (unchanged — source of truth) |
| `CHANGELOG.md` | 0.1.18 | 0.1.18 (unchanged) |
| `README.md` (EN + PL) | **0.1.15** | 0.1.18 |
| `SettingsWindowController.swift` | **0.1.17** | fallback removed |

### Changes

- **README "Latest changes" / "Najnowsze zmiany"** — bumped to 0.1.18 and
  rewritten from the 0.1.18 changelog entry. The previous text described
  0.1.15's TLS pinning and Local/Keychain downloads, so bumping the number
  alone would have left the section wrong in substance.
- **`SettingsWindowController.refresh()`** — replaced the hardcoded
  `?? "0.1.17"` with `?? "—"`. That fallback only fires when there is no
  bundle `Info.plist` to read (running the raw SPM binary rather than the
  built `.app`), so any version number there is a guess. A stale one is worse
  than none: it fails plausibly instead of visibly.

This leaves `Info.plist` as the single source of truth — `scripts/build-release.sh`
already reads it via `PlistBuddy` — and `CHANGELOG.md` as per-release history.
No third copy left to drift.

### Testing

- `swift build` — clean
- `./scripts/run-tests.sh` — 22 tests in 3 suites pass