### PR TITLE
Add Windows system tray app

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,41 @@
+name: Windows build
+
+on:
+  push:
+    paths:
+      - 'windows/**'
+      - '.github/workflows/windows.yml'
+  pull_request:
+    paths:
+      - 'windows/**'
+      - '.github/workflows/windows.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: windows
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore BambuBar.Windows/BambuBar.Windows.csproj
+      - name: Build
+        run: dotnet build BambuBar.Windows/BambuBar.Windows.csproj -c Release --no-restore
+      - name: Publish self-contained single-file exe
+        run: dotnet publish BambuBar.Windows/BambuBar.Windows.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false -o publish
+      - name: Package ZIP
+        shell: pwsh
+        run: Compress-Archive -Path publish/BambuBar.exe -DestinationPath publish/BambuBar-Windows-x64.zip -Force
+      - name: Upload packaged application
+        uses: actions/upload-artifact@v4
+        with:
+          name: BambuBar-Windows-x64
+          path: windows/publish/BambuBar-Windows-x64.zip
+          if-no-files-found: error

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,9 +19,9 @@ jobs:
         working-directory: windows
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
       - name: Restore
@@ -34,7 +34,7 @@ jobs:
         shell: pwsh
         run: Compress-Archive -Path publish/BambuBar.exe -DestinationPath publish/BambuBar-Windows-x64.zip -Force
       - name: Upload packaged application
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: BambuBar-Windows-x64
           path: windows/publish/BambuBar-Windows-x64.zip

--- a/README.md
+++ b/README.md
@@ -11,13 +11,23 @@
 
 ---
 
+## Downloads / Pobieranie
+
+- [macOS Local](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-0.1.18-macOS-Local.zip)
+- [macOS Keychain](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-0.1.18-macOS-Keychain.zip)
+- [Windows x64 — self-contained beta](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-Windows-x64.zip)
+
+The Windows build does not require a separate .NET installation. / Wersja Windows nie wymaga osobnej instalacji .NET.
+
+---
+
 ## English
 
-A compact, MIT-licensed macOS menu bar monitor for Bambu Lab 3D printers. BambuBar discovers printers on the local network and presents larger fleets in an adaptive two- or three-column macOS-style glass dashboard.
+A compact, MIT-licensed macOS menu bar and Windows system-tray monitor for Bambu Lab 3D printers. BambuBar discovers printers on the local network and presents larger fleets in an adaptive dashboard.
 
 ### Latest changes
 
-Version 0.1.15 adds TLS certificate pinning and two downloads: **Local** for convenient preference-based access-code storage, and **Keychain** for storage in the macOS Keychain.
+Version 0.1.18 adds the first self-contained Windows x64 beta alongside the macOS Local and Keychain builds.
 
 [Read the full changelog](CHANGELOG.md)
 
@@ -35,14 +45,16 @@ Version 0.1.15 adds TLS certificate pinning and two downloads: **Local** for con
 - offers a Local build and a macOS Keychain build
 - pins each printer's TLS certificate after the first trusted connection
 - communicates locally without requiring a Bambu Cloud account
+- includes a self-contained Windows x64 system-tray build with per-user DPAPI encryption
 
 ### Requirements
 
-- macOS 26 or newer
-- a Mac and the printers on the same local network
+- macOS 26 or newer, or 64-bit Windows 10/11 for the Windows beta
+- a Mac or PC and the printers on the same local network
 - LAN access enabled on each printer
 - the serial number and Access Code/PIN for each printer
 - Swift 6 and Xcode Command Line Tools when building from source
+- .NET 8 SDK when building the Windows version from source
 
 ### Adding printers
 
@@ -80,6 +92,8 @@ chmod +x scripts/build-app.sh scripts/build-release.sh
 
 The applications are created at `dist/BambuBar.app` and `dist/BambuBar Keychain.app`. Run `./scripts/build-release.sh` to create both release ZIP archives.
 
+See [windows/README.md](windows/README.md) for Windows build instructions. GitHub Actions produces a self-contained `BambuBar.exe` that does not require the .NET runtime on the target PC.
+
 On the first launch, allow Local Network access when macOS asks for it.
 
 ### Tests
@@ -109,11 +123,11 @@ BambuBar is an independent project and is not affiliated with, endorsed by or sp
 
 ## Polski
 
-Kompaktowy monitor drukarek 3D Bambu Lab dla paska menu macOS, na licencji MIT. BambuBar wykrywa drukarki w sieci lokalnej i prezentuje większe floty na adaptacyjnym, „szklanym" pulpicie w stylu macOS z dwiema lub trzema kolumnami.
+Kompaktowy monitor drukarek 3D Bambu Lab dla paska menu macOS i zasobnika systemowego Windows, na licencji MIT. BambuBar wykrywa drukarki w sieci lokalnej i prezentuje większe floty na adaptacyjnym pulpicie.
 
 ### Najnowsze zmiany
 
-Wersja 0.1.15 dodaje pinning certyfikatu TLS oraz dwa warianty do pobrania: **Local** — wygodne przechowywanie kodów dostępu w ustawieniach aplikacji, oraz **Keychain** — przechowywanie w pęku kluczy macOS.
+Wersja 0.1.18 dodaje pierwszą samodzielną betę Windows x64 obok wariantów macOS Local i Keychain.
 
 [Zobacz pełny changelog](CHANGELOG.md)
 
@@ -131,14 +145,16 @@ Wersja 0.1.15 dodaje pinning certyfikatu TLS oraz dwa warianty do pobrania: **Lo
 - oferuje wariant Local oraz wariant z pękiem kluczy macOS
 - przypina (pinuje) certyfikat TLS każdej drukarki po pierwszym zaufanym połączeniu
 - komunikuje się lokalnie, bez konieczności posiadania konta Bambu Cloud
+- zawiera samodzielną wersję dla Windows x64 z ikoną w zasobniku i szyfrowaniem DPAPI
 
 ### Wymagania
 
-- macOS 26 lub nowszy
-- Mac i drukarki w tej samej sieci lokalnej
+- macOS 26 lub nowszy albo 64-bitowy Windows 10/11 dla wersji beta
+- Mac lub PC i drukarki w tej samej sieci lokalnej
 - włączony dostęp LAN na każdej drukarce
 - numer seryjny i kod dostępu (Access Code / PIN) każdej drukarki
 - Swift 6 i Xcode Command Line Tools przy budowaniu ze źródeł
+- .NET 8 SDK przy budowaniu wersji Windows ze źródeł
 
 ### Dodawanie drukarek
 
@@ -175,6 +191,8 @@ chmod +x scripts/build-app.sh scripts/build-release.sh
 ```
 
 Aplikacje powstają jako `dist/BambuBar.app` oraz `dist/BambuBar Keychain.app`. Uruchom `./scripts/build-release.sh`, aby utworzyć oba archiwa ZIP do wydania.
+
+Instrukcja budowania wersji Windows znajduje się w [windows/README.md](windows/README.md). GitHub Actions tworzy samodzielny `BambuBar.exe`, który nie wymaga środowiska .NET na komputerze docelowym.
 
 Przy pierwszym uruchomieniu zezwól na dostęp do sieci lokalnej, gdy macOS o to zapyta.
 

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+publish/
+*.user
+.vs/

--- a/windows/BambuBar.Windows.sln
+++ b/windows/BambuBar.Windows.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BambuBar.Windows", "BambuBar.Windows\BambuBar.Windows.csproj", "{B0B0B0B0-1111-2222-3333-444455556666}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B0B0B0B0-1111-2222-3333-444455556666}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0B0B0B0-1111-2222-3333-444455556666}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0B0B0B0-1111-2222-3333-444455556666}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0B0B0B0-1111-2222-3333-444455556666}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/windows/BambuBar.Windows/App.xaml
+++ b/windows/BambuBar.Windows/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="BambuBar.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             ShutdownMode="OnExplicitShutdown">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/windows/BambuBar.Windows/App.xaml.cs
+++ b/windows/BambuBar.Windows/App.xaml.cs
@@ -1,0 +1,41 @@
+using System.Windows;
+using System.Windows.Threading;
+using BambuBar.Services;
+using BambuBar.UI;
+
+namespace BambuBar;
+
+public partial class App : Application
+{
+    private PrinterStore? _store;
+    private TrayIcon? _tray;
+
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+
+        // Windows-1252 is not registered by default on .NET 8; the status parser uses it to
+        // repair mis-encoded print names.
+        System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        _store = new PrinterStore(action =>
+        {
+            if (dispatcher.CheckAccess()) action();
+            else dispatcher.BeginInvoke(action);
+        });
+
+        _tray = new TrayIcon(_store);
+        NotificationService.Sink = (title, body, subtitle) => _tray.ShowNotification(title, body, subtitle);
+
+        if (LaunchAtLogin.IsEnabled) LaunchAtLogin.SetEnabled(true); // refresh path
+
+        _store.ReconnectAll();
+    }
+
+    protected override void OnExit(ExitEventArgs e)
+    {
+        _tray?.Dispose();
+        base.OnExit(e);
+    }
+}

--- a/windows/BambuBar.Windows/BambuBar.Windows.csproj
+++ b/windows/BambuBar.Windows/BambuBar.Windows.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>BambuBar</AssemblyName>
+    <RootNamespace>BambuBar</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Version>0.1.18</Version>
+    <Product>BambuBar</Product>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+  </ItemGroup>
+
+  <!-- WPF + WinForms both add implicit global usings; drop the WinForms ones so WPF types
+       (Application, Color, Button) are unambiguous. TrayIcon.cs imports them explicitly. -->
+  <ItemGroup>
+    <Using Remove="System.Windows.Forms" />
+    <Using Remove="System.Drawing" />
+  </ItemGroup>
+
+</Project>

--- a/windows/BambuBar.Windows/Models/PrinterModels.cs
+++ b/windows/BambuBar.Windows/Models/PrinterModels.cs
@@ -1,0 +1,116 @@
+using System.Text.Json.Serialization;
+
+namespace BambuBar.Models;
+
+public enum PrinterState
+{
+    Idle,
+    Printing,
+    Paused,
+    Finished,
+    Error,
+    Offline
+}
+
+public static class PrinterStateExtensions
+{
+    public static string Label(this PrinterState state, bool polish) => state switch
+    {
+        PrinterState.Idle => polish ? "Gotowa" : "Ready",
+        PrinterState.Printing => polish ? "Drukowanie" : "Printing",
+        PrinterState.Paused => polish ? "Wstrzymana" : "Paused",
+        PrinterState.Finished => polish ? "Zakończono" : "Finished",
+        PrinterState.Error => polish ? "Błąd" : "Error",
+        PrinterState.Offline => polish ? "Offline" : "Offline",
+        _ => "—"
+    };
+
+    /// <summary>Accent colour (hex, no #) used on the printer card, mirroring the macOS symbols.</summary>
+    public static string AccentHex(this PrinterState state) => state switch
+    {
+        PrinterState.Idle => "30D158",
+        PrinterState.Printing => "0A84FF",
+        PrinterState.Paused => "FF9F0A",
+        PrinterState.Finished => "30D158",
+        PrinterState.Error => "FF453A",
+        PrinterState.Offline => "8E8E93",
+        _ => "8E8E93"
+    };
+}
+
+/// <summary>Live telemetry for one printer. Reference type so incremental MQTT updates merge in place.</summary>
+public sealed class PrinterTelemetry
+{
+    public PrinterState State { get; set; } = PrinterState.Offline;
+    public int Progress { get; set; }
+    public int? RemainingMinutes { get; set; }
+    public double? NozzleTemperature { get; set; }
+    public double? NozzleTargetTemperature { get; set; }
+    public double? BedTemperature { get; set; }
+    public double? BedTargetTemperature { get; set; }
+    public double? ChamberTemperature { get; set; }
+    public int? CurrentLayer { get; set; }
+    public int? TotalLayers { get; set; }
+    public int? CurrentStage { get; set; }
+    public string? JobName { get; set; }
+    public ulong ErrorCode { get; set; }
+    public List<string> HmsCodes { get; set; } = new();
+    public List<AmsSlot> AmsSlots { get; set; } = new();
+    public int? AmsHumidity { get; set; }
+    public double? AmsTemperature { get; set; }
+    public DateTime? LastUpdated { get; set; }
+
+    public PrinterTelemetry Clone()
+    {
+        return new PrinterTelemetry
+        {
+            State = State,
+            Progress = Progress,
+            RemainingMinutes = RemainingMinutes,
+            NozzleTemperature = NozzleTemperature,
+            NozzleTargetTemperature = NozzleTargetTemperature,
+            BedTemperature = BedTemperature,
+            BedTargetTemperature = BedTargetTemperature,
+            ChamberTemperature = ChamberTemperature,
+            CurrentLayer = CurrentLayer,
+            TotalLayers = TotalLayers,
+            CurrentStage = CurrentStage,
+            JobName = JobName,
+            ErrorCode = ErrorCode,
+            HmsCodes = new List<string>(HmsCodes),
+            AmsSlots = AmsSlots.Select(s => s.Clone()).ToList(),
+            AmsHumidity = AmsHumidity,
+            AmsTemperature = AmsTemperature,
+            LastUpdated = LastUpdated
+        };
+    }
+}
+
+public sealed class AmsSlot
+{
+    public string Id { get; set; } = "";
+    public string Label { get; set; } = "";
+    public string Material { get; set; } = "";
+    public string ColorHex { get; set; } = "8E8E93FF";
+    public int? RemainingPercent { get; set; }
+    public bool IsActive { get; set; }
+    public bool IsExternal { get; set; }
+
+    public AmsSlot Clone() => (AmsSlot)MemberwiseClone();
+}
+
+public sealed class SavedPrinter
+{
+    [JsonPropertyName("serial")] public string Serial { get; set; } = "";
+    [JsonPropertyName("name")] public string Name { get; set; } = "";
+    [JsonPropertyName("model")] public string Model { get; set; } = "Bambu Lab";
+    [JsonPropertyName("host")] public string Host { get; set; } = "";
+}
+
+public sealed class DiscoveredPrinter
+{
+    public string Serial { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Model { get; set; } = "Bambu Lab";
+    public string Host { get; set; } = "";
+}

--- a/windows/BambuBar.Windows/Services/BambuStudioConfig.cs
+++ b/windows/BambuBar.Windows/Services/BambuStudioConfig.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using System.Text.Json;
+
+namespace BambuBar.Services;
+
+/// <summary>Reads locally stored printer access codes and IPs from Bambu Studio's config.</summary>
+public static class BambuStudioConfig
+{
+    public readonly record struct Device(string Serial, string AccessCode, string? Host);
+
+    /// <summary>Every printer with a saved access code, paired with its last known IP so printers
+    /// can be imported without a network scan.</summary>
+    public static List<Device> Devices()
+    {
+        var root = ReadRoot();
+        var codes = StringDictionary(root, "access_code");
+        foreach (var kv in StringDictionary(root, "user_access_code")) codes[kv.Key] = kv.Value; // user codes win
+        codes = codes.Where(kv => kv.Key.Length > 0 && kv.Value.Length > 0).ToDictionary(kv => kv.Key, kv => kv.Value);
+        if (codes.Count == 0)
+            throw new BambuStudioConfigException(AppSettings.Text("Bambu Studio nie ma zapisanych kodów drukarek.", "Bambu Studio has no stored printer codes."));
+
+        var ips = StringDictionary(root, "ip_address");
+        return codes.Select(kv =>
+        {
+            string? host = ips.TryGetValue(kv.Key, out var h) && h.Length > 0 ? h : null;
+            return new Device(kv.Key, kv.Value, host);
+        }).ToList();
+    }
+
+    public static Dictionary<string, string> AccessCodes()
+        => Devices().ToDictionary(d => d.Serial, d => d.AccessCode);
+
+    private static JsonElement ReadRoot()
+    {
+        var path = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "BambuStudio", "BambuStudio.conf");
+        if (!File.Exists(path))
+            throw new BambuStudioConfigException(AppSettings.Text("Nie znaleziono konfiguracji Bambu Studio.", "Bambu Studio configuration not found."));
+        try { return JsonDocument.Parse(File.ReadAllText(path)).RootElement.Clone(); }
+        catch { throw new BambuStudioConfigException(AppSettings.Text("Nie udało się odczytać konfiguracji Bambu Studio.", "Could not read the Bambu Studio configuration.")); }
+    }
+
+    private static Dictionary<string, string> StringDictionary(JsonElement root, string key)
+    {
+        var dict = new Dictionary<string, string>();
+        if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty(key, out var obj) && obj.ValueKind == JsonValueKind.Object)
+            foreach (var prop in obj.EnumerateObject())
+                if (prop.Value.ValueKind == JsonValueKind.String)
+                    dict[prop.Name] = prop.Value.GetString()!;
+        return dict;
+    }
+}
+
+public sealed class BambuStudioConfigException : Exception
+{
+    public BambuStudioConfigException(string message) : base(message) { }
+}

--- a/windows/BambuBar.Windows/Services/CertificatePinStore.cs
+++ b/windows/BambuBar.Windows/Services/CertificatePinStore.cs
@@ -1,0 +1,42 @@
+using System.Security.Cryptography;
+
+namespace BambuBar.Services;
+
+/// <summary>Pins each printer's TLS certificate after first use, ported from the macOS store.</summary>
+public static class CertificatePinStore
+{
+    public enum ValidationResult
+    {
+        FirstUse,
+        Matched,
+        Mismatch
+    }
+
+    public static bool Accepted(this ValidationResult result) => result != ValidationResult.Mismatch;
+
+    private static readonly object Gate = new();
+    private const string Key = "printer-certificate-pins-v1";
+
+    public static ValidationResult Validate(byte[] certificateData, string serial)
+    {
+        string fingerprint = Convert.ToHexString(SHA256.HashData(certificateData)).ToLowerInvariant();
+        lock (Gate)
+        {
+            var pins = Defaults.GetStringDictionary(Key);
+            if (pins.TryGetValue(serial, out var stored))
+                return stored == fingerprint ? ValidationResult.Matched : ValidationResult.Mismatch;
+            pins[serial] = fingerprint;
+            Defaults.SetStringDictionary(Key, pins);
+            return ValidationResult.FirstUse;
+        }
+    }
+
+    public static void Delete(string serial)
+    {
+        lock (Gate)
+        {
+            var pins = Defaults.GetStringDictionary(Key);
+            if (pins.Remove(serial)) Defaults.SetStringDictionary(Key, pins);
+        }
+    }
+}

--- a/windows/BambuBar.Windows/Services/HmsResolver.cs
+++ b/windows/BambuBar.Windows/Services/HmsResolver.cs
@@ -1,0 +1,102 @@
+using System.IO;
+using System.Text.Json;
+
+namespace BambuBar.Services;
+
+/// <summary>
+/// Resolves HMS error codes to human-readable text using Bambu Studio's bundled HMS files,
+/// ported from the macOS HMSResolver. Looks the app up in the usual Windows install locations.
+/// </summary>
+public static class HmsResolver
+{
+    private static readonly object Gate = new();
+    private static readonly Dictionary<string, Dictionary<string, string>> Cache = new();
+
+    public static string? Description(IReadOnlyList<string> codes, string serial, bool polish)
+    {
+        if (codes.Count == 0) return null;
+        string prefix = (serial.Length >= 3 ? serial[..3] : serial).ToUpperInvariant();
+        string languageCode = polish ? "pl" : "en";
+        var lookup = Messages(prefix, languageCode);
+        foreach (var code in codes)
+        {
+            var normalized = Normalize(code);
+            if (lookup.TryGetValue(normalized, out var message) && message.Length > 0)
+                return message;
+        }
+        return codes.Count > 0 ? $"HMS {codes[0]}" : null;
+    }
+
+    private static Dictionary<string, string> Messages(string prefix, string languageCode)
+    {
+        string cacheKey = $"{languageCode}-{prefix}";
+        lock (Gate)
+        {
+            if (Cache.TryGetValue(cacheKey, out var cached)) return cached;
+            var result = new Dictionary<string, string>();
+            var path = HmsFile(languageCode, prefix);
+            if (path is not null)
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(File.ReadAllText(path));
+                    Collect(doc.RootElement, languageCode, result);
+                }
+                catch { /* leave empty */ }
+            }
+            Cache[cacheKey] = result;
+            return result;
+        }
+    }
+
+    private static string? HmsFile(string languageCode, string prefix)
+    {
+        foreach (var root in InstallRoots())
+        {
+            var candidate = Path.Combine(root, "resources", "hms", $"hms_{languageCode}_{prefix}.json");
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    private static IEnumerable<string> InstallRoots()
+    {
+        foreach (var special in new[] { Environment.SpecialFolder.ProgramFiles, Environment.SpecialFolder.ProgramFilesX86, Environment.SpecialFolder.LocalApplicationData })
+        {
+            var baseDir = Environment.GetFolderPath(special);
+            if (string.IsNullOrEmpty(baseDir)) continue;
+            yield return Path.Combine(baseDir, "Bambu Studio");
+            yield return Path.Combine(baseDir, "BambuStudio");
+            yield return Path.Combine(baseDir, "Programs", "Bambu Studio");
+        }
+    }
+
+    private static void Collect(JsonElement value, string languageCode, Dictionary<string, string> result)
+    {
+        if (value.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in value.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.Object &&
+                    item.TryGetProperty("ecode", out var ecode) && ecode.ValueKind == JsonValueKind.String &&
+                    item.TryGetProperty("intro", out var intro) && intro.ValueKind == JsonValueKind.String &&
+                    intro.GetString() is { Length: > 0 } introText)
+                {
+                    result[Normalize(ecode.GetString()!)] = introText.Normalize(System.Text.NormalizationForm.FormC);
+                }
+                else
+                {
+                    Collect(item, languageCode, result);
+                }
+            }
+        }
+        else if (value.ValueKind == JsonValueKind.Object)
+        {
+            if (value.TryGetProperty(languageCode, out var localized)) Collect(localized, languageCode, result);
+            foreach (var prop in value.EnumerateObject())
+                if (prop.Name != languageCode) Collect(prop.Value, languageCode, result);
+        }
+    }
+
+    private static string Normalize(string code) => code.Replace("_", "").ToUpperInvariant();
+}

--- a/windows/BambuBar.Windows/Services/LaunchAtLogin.cs
+++ b/windows/BambuBar.Windows/Services/LaunchAtLogin.cs
@@ -1,0 +1,43 @@
+using Microsoft.Win32;
+
+namespace BambuBar.Services;
+
+/// <summary>Start-with-Windows toggle via the HKCU Run key, the Windows counterpart of Launch at Login.</summary>
+public static class LaunchAtLogin
+{
+    private const string RunKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
+    private const string ValueName = "BambuBar";
+
+    public static bool IsEnabled
+    {
+        get
+        {
+            try
+            {
+                using var key = Registry.CurrentUser.OpenSubKey(RunKey);
+                return key?.GetValue(ValueName) is string;
+            }
+            catch { return false; }
+        }
+    }
+
+    public static void SetEnabled(bool enabled)
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RunKey, writable: true)
+                            ?? Registry.CurrentUser.CreateSubKey(RunKey);
+            if (key is null) return;
+            if (enabled)
+            {
+                var exe = Environment.ProcessPath ?? System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
+                if (!string.IsNullOrEmpty(exe)) key.SetValue(ValueName, $"\"{exe}\"");
+            }
+            else
+            {
+                key.DeleteValue(ValueName, throwOnMissingValue: false);
+            }
+        }
+        catch { /* ignore registry failures */ }
+    }
+}

--- a/windows/BambuBar.Windows/Services/MqttClient.cs
+++ b/windows/BambuBar.Windows/Services/MqttClient.cs
@@ -1,0 +1,190 @@
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using BambuBar.Models;
+
+namespace BambuBar.Services;
+
+public enum MqttEventType { Connected, Telemetry, Disconnected }
+
+public sealed class MqttEvent
+{
+    public MqttEventType Type { get; init; }
+    public PrinterTelemetry? Telemetry { get; init; }
+    public string? Reason { get; init; }
+}
+
+/// <summary>
+/// One MQTT-over-TLS connection to a printer, ported from the macOS MQTTClient.
+/// Raises Connected / Telemetry / Disconnected events; reconnection is driven by PrinterStore.
+/// </summary>
+public sealed class MqttClient
+{
+    private readonly SavedPrinter _printer;
+    private readonly string _accessCode;
+    private readonly Action<MqttEvent> _onEvent;
+    private readonly CancellationTokenSource _cts = new();
+
+    private TcpClient? _tcp;
+    private SslStream? _ssl;
+    private PrinterTelemetry _telemetry = new();
+    private bool _certificateMismatch;
+    private bool _disconnectReported;
+
+    public MqttClient(SavedPrinter printer, string accessCode, Action<MqttEvent> onEvent)
+    {
+        _printer = printer;
+        _accessCode = accessCode;
+        _onEvent = onEvent;
+    }
+
+    public void Start() => _ = Task.Run(RunAsync);
+
+    public void Stop()
+    {
+        try { _cts.Cancel(); } catch { }
+        try { _ssl?.Dispose(); } catch { }
+        try { _tcp?.Close(); } catch { }
+    }
+
+    private async Task RunAsync()
+    {
+        try
+        {
+            _tcp = new TcpClient { NoDelay = true };
+            using var connectTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, connectTimeout.Token);
+            try
+            {
+                await _tcp.ConnectAsync(_printer.Host, 8883, linked.Token);
+            }
+            catch (OperationCanceledException) when (connectTimeout.IsCancellationRequested)
+            {
+                ReportDisconnected(AppSettings.Text("Przekroczono czas połączenia z drukarką", "Connection to the printer timed out"));
+                return;
+            }
+
+            // The validation callback lives in the options only; setting it in the SslStream
+            // constructor as well would throw at authentication time.
+            _ssl = new SslStream(_tcp.GetStream(), false);
+            var options = new SslClientAuthenticationOptions
+            {
+                TargetHost = _printer.Host,
+                RemoteCertificateValidationCallback = ValidateCertificate,
+                EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls13
+            };
+            try
+            {
+                await _ssl.AuthenticateAsClientAsync(options, _cts.Token);
+            }
+            catch
+            {
+                ReportDisconnected(_certificateMismatch ? CertificateMismatchMessage : AppSettings.Text("Nie udało się nawiązać połączenia TLS", "TLS handshake failed"));
+                return;
+            }
+
+            string clientId = "BambuBar-" + Guid.NewGuid().ToString("N")[..8];
+            await SendAsync(MqttCodec.Connect(clientId, "bblp", _accessCode));
+
+            _ = PingLoopAsync();
+            await ReadLoopAsync();
+        }
+        catch (OperationCanceledException) { /* stopped */ }
+        catch (Exception ex)
+        {
+            ReportDisconnected(ex.Message);
+        }
+    }
+
+    private bool ValidateCertificate(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors errors)
+    {
+        if (certificate is null) return false;
+        var result = CertificatePinStore.Validate(certificate.GetRawCertData(), _printer.Serial);
+        _certificateMismatch = result == CertificatePinStore.ValidationResult.Mismatch;
+        return result.Accepted();
+    }
+
+    private async Task ReadLoopAsync()
+    {
+        var buffer = Array.Empty<byte>();
+        var chunk = new byte[65536];
+        while (!_cts.IsCancellationRequested)
+        {
+            int read;
+            try { read = await _ssl!.ReadAsync(chunk, _cts.Token); }
+            catch (OperationCanceledException) { return; }
+            catch (Exception ex) { ReportDisconnected(ex.Message); return; }
+            if (read <= 0) { ReportDisconnected(null); return; }
+
+            var grown = new byte[buffer.Length + read];
+            Array.Copy(buffer, grown, buffer.Length);
+            Array.Copy(chunk, 0, grown, buffer.Length, read);
+            buffer = grown;
+
+            foreach (var packet in MqttCodec.ExtractPackets(ref buffer))
+            {
+                switch (packet.Type >> 4)
+                {
+                    case 2: // CONNACK
+                        if (packet.Body.Length < 2 || packet.Body[1] != 0)
+                        {
+                            ReportDisconnected(AppSettings.Text("Drukarka odrzuciła kod dostępu", "The printer rejected the access code"));
+                            Stop();
+                            return;
+                        }
+                        _onEvent(new MqttEvent { Type = MqttEventType.Connected });
+                        await SendAsync(MqttCodec.Subscribe($"device/{_printer.Serial}/report"));
+                        var request = Encoding.UTF8.GetBytes("{\"pushing\":{\"sequence_id\":\"0\",\"command\":\"pushall\"}}");
+                        await SendAsync(MqttCodec.Publish($"device/{_printer.Serial}/request", request));
+                        break;
+                    case 3: // PUBLISH
+                        var payload = MqttCodec.PublishPayload(packet.Type, packet.Body);
+                        if (payload is null) continue;
+                        var updated = StatusParser.Telemetry(payload, _telemetry);
+                        if (updated is null) continue;
+                        _telemetry = updated;
+                        _onEvent(new MqttEvent { Type = MqttEventType.Telemetry, Telemetry = updated });
+                        break;
+                }
+            }
+        }
+    }
+
+    private async Task PingLoopAsync()
+    {
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(30), _cts.Token);
+                await SendAsync(MqttCodec.Ping());
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch { /* connection torn down elsewhere */ }
+    }
+
+    private readonly SemaphoreSlim _sendGate = new(1, 1);
+
+    private async Task SendAsync(byte[] data)
+    {
+        if (_ssl is null) return;
+        await _sendGate.WaitAsync(_cts.Token);
+        try { await _ssl.WriteAsync(data, _cts.Token); }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { ReportDisconnected(ex.Message); }
+        finally { _sendGate.Release(); }
+    }
+
+    private void ReportDisconnected(string? reason)
+    {
+        if (_disconnectReported) return;
+        _disconnectReported = true;
+        _onEvent(new MqttEvent { Type = MqttEventType.Disconnected, Reason = reason });
+    }
+
+    private static string CertificateMismatchMessage => AppSettings.Text(
+        "Certyfikat drukarki zmienił się. Połączenie zablokowano; usuń i dodaj drukarkę ponownie.",
+        "The printer certificate changed. Connection blocked; remove and re-add the printer.");
+}

--- a/windows/BambuBar.Windows/Services/MqttCodec.cs
+++ b/windows/BambuBar.Windows/Services/MqttCodec.cs
@@ -1,0 +1,110 @@
+using System.Text;
+
+namespace BambuBar.Services;
+
+/// <summary>Minimal MQTT 3.1.1 framing, ported 1:1 from the macOS MQTTCodec.</summary>
+public static class MqttCodec
+{
+    public static byte[] Connect(string clientId, string username, string password)
+    {
+        var body = new List<byte> { 0, 4 };
+        body.AddRange(Encoding.ASCII.GetBytes("MQTT"));
+        body.Add(4);
+        body.Add(0xC2); // username + password + clean session
+        body.AddRange(new byte[] { 0, 60 });
+        body.AddRange(MqttString(clientId));
+        body.AddRange(MqttString(username));
+        body.AddRange(MqttString(password));
+        return Packet(0x10, body);
+    }
+
+    public static byte[] Subscribe(string topic, ushort packetId = 1)
+    {
+        var body = new List<byte> { (byte)(packetId >> 8), (byte)(packetId & 0xff) };
+        body.AddRange(MqttString(topic));
+        body.Add(0);
+        return Packet(0x82, body);
+    }
+
+    public static byte[] Publish(string topic, byte[] payload)
+    {
+        var body = new List<byte>();
+        body.AddRange(MqttString(topic));
+        body.AddRange(payload);
+        return Packet(0x30, body);
+    }
+
+    public static byte[] Ping() => new byte[] { 0xC0, 0 };
+
+    /// <summary>Extracts whole packets from the receive buffer, leaving any partial trailing packet behind.</summary>
+    public static List<(byte Type, byte[] Body)> ExtractPackets(ref byte[] buffer)
+    {
+        var packets = new List<(byte, byte[])>();
+        int start = 0;
+        while (buffer.Length - start >= 2)
+        {
+            int multiplier = 1;
+            int remaining = 0;
+            int index = start + 1;
+            bool finishedLength = false;
+            while (index < buffer.Length && index <= start + 4)
+            {
+                int b = buffer[index];
+                remaining += (b & 127) * multiplier;
+                index += 1;
+                if ((b & 128) == 0) { finishedLength = true; break; }
+                multiplier *= 128;
+            }
+            if (!finishedLength || buffer.Length < index + remaining) break;
+            var body = new byte[remaining];
+            Array.Copy(buffer, index, body, 0, remaining);
+            packets.Add((buffer[start], body));
+            start = index + remaining;
+        }
+        if (start > 0)
+        {
+            var rest = new byte[buffer.Length - start];
+            Array.Copy(buffer, start, rest, 0, rest.Length);
+            buffer = rest;
+        }
+        return packets;
+    }
+
+    public static byte[]? PublishPayload(byte header, byte[] body)
+    {
+        if ((header >> 4) != 3 || body.Length < 2) return null;
+        int topicLength = (body[0] << 8) | body[1];
+        int offset = 2 + topicLength;
+        int qos = (header >> 1) & 0x03;
+        if (qos > 0) offset += 2;
+        if (offset > body.Length) return null;
+        var payload = new byte[body.Length - offset];
+        Array.Copy(body, offset, payload, 0, payload.Length);
+        return payload;
+    }
+
+    private static byte[] Packet(byte header, List<byte> body)
+    {
+        var result = new List<byte> { header };
+        int length = body.Count;
+        do
+        {
+            byte b = (byte)(length % 128);
+            length /= 128;
+            if (length > 0) b |= 128;
+            result.Add(b);
+        } while (length > 0);
+        result.AddRange(body);
+        return result.ToArray();
+    }
+
+    private static byte[] MqttString(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        var result = new byte[2 + bytes.Length];
+        result[0] = (byte)(bytes.Length >> 8);
+        result[1] = (byte)(bytes.Length & 0xff);
+        Array.Copy(bytes, 0, result, 2, bytes.Length);
+        return result;
+    }
+}

--- a/windows/BambuBar.Windows/Services/NotificationService.cs
+++ b/windows/BambuBar.Windows/Services/NotificationService.cs
@@ -1,0 +1,15 @@
+namespace BambuBar.Services;
+
+/// <summary>
+/// Posts user notifications. The tray icon wires up the actual sink (a balloon tip) at startup;
+/// until then posts are ignored, mirroring the macOS NotificationService abstraction.
+/// </summary>
+public static class NotificationService
+{
+    public static Action<string, string, string?>? Sink { get; set; }
+
+    public static void Post(string title, string body, string? subtitle = null)
+    {
+        Sink?.Invoke(title, body, subtitle);
+    }
+}

--- a/windows/BambuBar.Windows/Services/PrinterStore.cs
+++ b/windows/BambuBar.Windows/Services/PrinterStore.cs
@@ -1,0 +1,420 @@
+using BambuBar.Models;
+
+namespace BambuBar.Services;
+
+/// <summary>
+/// Central coordinator: owns the printer list, live telemetry, MQTT clients, reconnection and
+/// notifications. Ported from the macOS PrinterStore. All mutations happen on the UI thread via
+/// the supplied <c>post</c> marshaller; subscribers refresh on the <see cref="Updated"/> event.
+/// </summary>
+public sealed class PrinterStore
+{
+    private readonly Action<Action> _post;
+
+    public List<SavedPrinter> Printers { get; private set; }
+    public Dictionary<string, PrinterTelemetry> Telemetry { get; } = new();
+    public Dictionary<string, string?> ConnectionMessages { get; } = new();
+    public List<DiscoveredPrinter> Discovered { get; private set; } = new();
+    public bool IsScanning { get; private set; }
+    public string? GlobalMessage { get; set; }
+
+    public event EventHandler? Updated;
+
+    private readonly SsdpDiscovery _discovery = new();
+    private readonly SubnetDiscovery _subnetDiscovery = new();
+    private readonly Dictionary<string, MqttClient> _clients = new();
+    private readonly Dictionary<string, CancellationTokenSource> _reconnectTasks = new();
+    private readonly Dictionary<string, string> _sessionCodes = new();
+    private readonly Dictionary<string, string> _dismissedJobs = new();
+    private readonly HashSet<string> _printersWithTelemetry = new();
+    private DateTime? _lastAddressScan;
+    private Guid _scanToken;
+
+    public PrinterStore(Action<Action> post)
+    {
+        _post = post;
+        Printers = SavedPrinterStore.Load();
+        foreach (var printer in Printers) Telemetry[printer.Serial] = new PrinterTelemetry();
+    }
+
+    public int ActivePrintCount => Telemetry.Values.Count(t => t.State == PrinterState.Printing);
+
+    private void RaiseUpdated() => Updated?.Invoke(this, EventArgs.Empty);
+
+    // ---- Discovery -----------------------------------------------------------------
+
+    public void Scan()
+    {
+        if (IsScanning) return;
+        var token = Guid.NewGuid();
+        _scanToken = token;
+        IsScanning = true;
+        GlobalMessage = null;
+        RaiseUpdated();
+
+        _ = Task.Run(async () =>
+        {
+            var ssdp = _discovery.ScanAsync();
+            var subnet = _subnetDiscovery.ScanAsync();
+            await Task.WhenAll(ssdp, subnet);
+            var combined = ssdp.Result.Concat(subnet.Result)
+                .GroupBy(p => p.Serial).Select(g => g.First());
+
+            _post(() =>
+            {
+                if (_scanToken != token) return;
+                Discovered = combined
+                    .Where(c => Printers.All(p => p.Serial != c.Serial))
+                    .OrderBy(c => c.Host, new NumericHostComparer())
+                    .ToList();
+                IsScanning = false;
+                if (Discovered.Count == 0)
+                    GlobalMessage = AppSettings.Text("Nie znaleziono nowych drukarek.", "No new printers found.");
+                RaiseUpdated();
+            });
+        });
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(8));
+            _post(() =>
+            {
+                if (_scanToken != token || !IsScanning) return;
+                IsScanning = false;
+                GlobalMessage = AppSettings.Text("Skanowanie przekroczyło 8 sekund.", "Scan exceeded 8 seconds.");
+                RaiseUpdated();
+            });
+        });
+    }
+
+    // ---- Adding / editing ----------------------------------------------------------
+
+    public void Add(DiscoveredPrinter discovered, string accessCode, string? customName = null)
+    {
+        var code = accessCode.Trim();
+        if (code.Length == 0) throw new ArgumentException(AppSettings.Text("Podaj kod PIN / Access Code drukarki.", "Enter the printer PIN / Access Code."));
+        var name = customName?.Trim();
+        var printer = new SavedPrinter
+        {
+            Serial = discovered.Serial,
+            Name = !string.IsNullOrEmpty(name) ? name! : discovered.Name,
+            Model = discovered.Model,
+            Host = discovered.Host
+        };
+        Upsert(printer, code);
+        Discovered.RemoveAll(d => d.Serial == printer.Serial);
+        RaiseUpdated();
+    }
+
+    public void AddManually(string name, string serial, string host, string accessCode)
+    {
+        var cleanSerial = serial.Trim();
+        var cleanHost = host.Trim();
+        var cleanCode = accessCode.Trim();
+        if (cleanSerial.Length == 0 || cleanHost.Length == 0 || cleanCode.Length == 0)
+            throw new ArgumentException(AppSettings.Text("Adres IP, numer seryjny i kod dostępu są wymagane.", "IP address, serial number and access code are required."));
+        var cleanName = name.Trim();
+        string suffix = cleanSerial.Length >= 4 ? cleanSerial[^4..] : cleanSerial;
+        Upsert(new SavedPrinter
+        {
+            Serial = cleanSerial,
+            Name = cleanName.Length == 0 ? $"Bambu {suffix}" : cleanName,
+            Host = cleanHost
+        }, cleanCode);
+        RaiseUpdated();
+    }
+
+    public int ImportFromBambuStudio()
+    {
+        var devices = BambuStudioConfig.Devices();
+        int imported = 0;
+
+        // Prefer an address we already know (saved printer or a fresh discovery hit) and fall
+        // back to the IP stored in the Bambu Studio config, so import works on a clean install
+        // with no saved printers and without waiting for a network scan.
+        foreach (var device in devices)
+        {
+            var existing = Printers.FirstOrDefault(p => p.Serial == device.Serial);
+            var found = Discovered.FirstOrDefault(d => d.Serial == device.Serial);
+            var host = existing?.Host ?? found?.Host ?? device.Host;
+            if (string.IsNullOrEmpty(host)) continue;
+            string suffix = device.Serial.Length >= 4 ? device.Serial[^4..] : device.Serial;
+            var name = existing?.Name ?? found?.Name ?? $"Bambu {suffix}";
+            var model = found?.Model ?? existing?.Model ?? "Bambu Lab";
+            Upsert(new SavedPrinter { Serial = device.Serial, Name = name, Model = model, Host = host }, device.AccessCode);
+            imported++;
+        }
+
+        Discovered.RemoveAll(d => devices.Any(x => x.Serial == d.Serial));
+        if (imported == 0)
+            throw new BambuStudioConfigException(AppSettings.Text("Nie znaleziono drukarek z zapisanym kodem i adresem IP.", "No printers with a stored code and IP address."));
+        RaiseUpdated();
+        return imported;
+    }
+
+    public void Update(string originalSerial, string name, string serial, string host, string accessCode)
+    {
+        var cleanSerial = serial.Trim();
+        var cleanHost = host.Trim();
+        var cleanName = name.Trim();
+        var entered = accessCode.Trim();
+        if (cleanSerial.Length == 0 || cleanHost.Length == 0)
+            throw new ArgumentException(AppSettings.Text("Adres IP i numer seryjny są wymagane.", "IP address and serial number are required."));
+        string? code = entered.Length == 0
+            ? (_sessionCodes.TryGetValue(originalSerial, out var s) ? s : AccessCodeStore.AccessCode(originalSerial))
+            : entered;
+        if (string.IsNullOrEmpty(code))
+            throw new ArgumentException(AppSettings.Text("Podaj kod PIN / Access Code drukarki.", "Enter the printer PIN / Access Code."));
+
+        if (_clients.Remove(originalSerial, out var existing)) existing.Stop();
+        if (originalSerial != cleanSerial)
+        {
+            Printers.RemoveAll(p => p.Serial == originalSerial);
+            Telemetry.Remove(originalSerial);
+            ConnectionMessages.Remove(originalSerial);
+            AccessCodeStore.Delete(originalSerial);
+            CertificatePinStore.Delete(originalSerial);
+        }
+        string suffix = cleanSerial.Length >= 4 ? cleanSerial[^4..] : cleanSerial;
+        Upsert(new SavedPrinter
+        {
+            Serial = cleanSerial,
+            Name = cleanName.Length == 0 ? $"Bambu {suffix}" : cleanName,
+            Host = cleanHost
+        }, code);
+        RaiseUpdated();
+    }
+
+    public void Remove(SavedPrinter printer)
+    {
+        if (_reconnectTasks.Remove(printer.Serial, out var task)) task.Cancel();
+        if (_clients.Remove(printer.Serial, out var client)) client.Stop();
+        _sessionCodes.Remove(printer.Serial);
+        Printers.RemoveAll(p => p.Serial == printer.Serial);
+        Telemetry.Remove(printer.Serial);
+        ConnectionMessages.Remove(printer.Serial);
+        AccessCodeStore.Delete(printer.Serial);
+        CertificatePinStore.Delete(printer.Serial);
+        SavedPrinterStore.Save(Printers);
+        RaiseUpdated();
+    }
+
+    public void ResetCompletedStatuses()
+    {
+        foreach (var serial in Telemetry.Keys.ToList())
+        {
+            var current = Telemetry[serial];
+            if (current.State is PrinterState.Printing or PrinterState.Paused) continue;
+            if (!string.IsNullOrEmpty(current.JobName)) _dismissedJobs[serial] = current.JobName!;
+            Telemetry[serial] = ClearedCompletedJob(current);
+            ConnectionMessages[serial] = null;
+        }
+        RaiseUpdated();
+    }
+
+    // ---- Connection lifecycle ------------------------------------------------------
+
+    public void ReconnectAll()
+    {
+        foreach (var printer in Printers.ToList()) Reconnect(printer);
+    }
+
+    public void Reconnect(SavedPrinter printer)
+    {
+        if (_reconnectTasks.Remove(printer.Serial, out var task)) task.Cancel();
+        if (_clients.Remove(printer.Serial, out var existing)) existing.Stop();
+        Telemetry[printer.Serial] = new PrinterTelemetry();
+        ConnectionMessages[printer.Serial] = AppSettings.Text("Łączenie…", "Connecting…");
+
+        string code;
+        if (_sessionCodes.TryGetValue(printer.Serial, out var sessionCode))
+        {
+            code = sessionCode;
+        }
+        else
+        {
+            try
+            {
+                code = AccessCodeStore.ReadAccessCode(printer.Serial);
+                _sessionCodes[printer.Serial] = code;
+            }
+            catch (Exception ex)
+            {
+                ConnectionMessages[printer.Serial] = ex.Message;
+                RaiseUpdated();
+                return;
+            }
+        }
+
+        var client = new MqttClient(printer, code, evt => _post(() => Handle(evt, printer.Serial)));
+        _clients[printer.Serial] = client;
+        client.Start();
+        RaiseUpdated();
+    }
+
+    private void Upsert(SavedPrinter printer, string accessCode)
+    {
+        AccessCodeStore.Save(accessCode, printer.Serial);
+        _sessionCodes[printer.Serial] = accessCode;
+        var index = Printers.FindIndex(p => p.Serial == printer.Serial);
+        if (index >= 0) Printers[index] = printer; else Printers.Add(printer);
+        Telemetry[printer.Serial] = new PrinterTelemetry();
+        SavedPrinterStore.Save(Printers);
+        Reconnect(printer);
+    }
+
+    private void Handle(MqttEvent evt, string serial)
+    {
+        switch (evt.Type)
+        {
+            case MqttEventType.Connected:
+                if (_reconnectTasks.Remove(serial, out var t)) t.Cancel();
+                ConnectionMessages[serial] = null;
+                break;
+
+            case MqttEventType.Telemetry:
+                if (_reconnectTasks.Remove(serial, out var t2)) t2.Cancel();
+                var value = evt.Telemetry!;
+                var previous = Telemetry.TryGetValue(serial, out var prev) ? prev : null;
+                if (value.State is PrinterState.Printing or PrinterState.Paused)
+                    _dismissedJobs.Remove(serial);
+                else if (_dismissedJobs.TryGetValue(serial, out var dismissed) && value.JobName == dismissed)
+                    value = ClearedCompletedJob(value);
+                else if (value.JobName != (_dismissedJobs.TryGetValue(serial, out var d) ? d : null))
+                    _dismissedJobs.Remove(serial);
+                Telemetry[serial] = value;
+                ConnectionMessages[serial] = null;
+                if (_printersWithTelemetry.Contains(serial) && Printers.FirstOrDefault(p => p.Serial == serial) is { } printer)
+                    NotifyChanges(printer, previous, value);
+                _printersWithTelemetry.Add(serial);
+                break;
+
+            case MqttEventType.Disconnected:
+                var offline = Telemetry.TryGetValue(serial, out var o) ? o : new PrinterTelemetry();
+                offline.State = PrinterState.Offline;
+                Telemetry[serial] = offline;
+                ConnectionMessages[serial] = (evt.Reason ?? AppSettings.Text("Rozłączono", "Disconnected")) +
+                                             AppSettings.Text(" • ponowna próba za 20 s", " • retrying in 20 s");
+                ScheduleReconnect(serial);
+                break;
+        }
+        RaiseUpdated();
+    }
+
+    private void ScheduleReconnect(string serial)
+    {
+        if (_reconnectTasks.ContainsKey(serial)) return;
+        if (Printers.All(p => p.Serial != serial)) return;
+        var cts = new CancellationTokenSource();
+        _reconnectTasks[serial] = cts;
+        _ = Task.Run(async () =>
+        {
+            try { await Task.Delay(TimeSpan.FromSeconds(20), cts.Token); }
+            catch (OperationCanceledException) { return; }
+
+            bool refreshNeeded = _lastAddressScan is null || (DateTime.Now - _lastAddressScan.Value).TotalSeconds >= 300;
+            if (refreshNeeded)
+            {
+                _lastAddressScan = DateTime.Now;
+                _post(() => { ConnectionMessages[serial] = AppSettings.Text("Szukam aktualnego adresu IP…", "Looking up current IP…"); RaiseUpdated(); });
+                await RefreshAddressesAsync();
+            }
+
+            _post(() =>
+            {
+                _reconnectTasks.Remove(serial);
+                if (cts.IsCancellationRequested) return;
+                if (Telemetry.TryGetValue(serial, out var tel) && tel.State != PrinterState.Offline) return;
+                var printer = Printers.FirstOrDefault(p => p.Serial == serial);
+                if (printer is not null) Reconnect(printer);
+            });
+        });
+    }
+
+    private async Task RefreshAddressesAsync()
+    {
+        var ssdp = _discovery.ScanAsync(3);
+        var subnet = _subnetDiscovery.ScanAsync();
+        await Task.WhenAll(ssdp, subnet);
+        var results = ssdp.Result.Concat(subnet.Result).ToList();
+        _post(() =>
+        {
+            bool changed = false;
+            foreach (var found in results)
+            {
+                var index = Printers.FindIndex(p => p.Serial == found.Serial);
+                if (index < 0) continue;
+                if (Printers[index].Host != found.Host) { Printers[index].Host = found.Host; changed = true; }
+            }
+            if (changed) SavedPrinterStore.Save(Printers);
+        });
+    }
+
+    private static PrinterTelemetry ClearedCompletedJob(PrinterTelemetry telemetry)
+    {
+        var cleared = telemetry.Clone();
+        if (cleared.State == PrinterState.Finished) cleared.State = PrinterState.Idle;
+        cleared.Progress = 0;
+        cleared.RemainingMinutes = null;
+        cleared.CurrentLayer = null;
+        cleared.TotalLayers = null;
+        cleared.JobName = null;
+        return cleared;
+    }
+
+    private void NotifyChanges(SavedPrinter printer, PrinterTelemetry? previous, PrinterTelemetry current)
+    {
+        bool pl = AppSettings.Polish;
+        if (current.State == PrinterState.Finished && previous?.State != PrinterState.Finished)
+            NotificationService.Post(AppSettings.Text("Druk zakończony", "Print finished"),
+                current.JobName ?? AppSettings.Text("Zadanie zostało ukończone.", "The job has completed."), printer.Name);
+
+        if (current.State == PrinterState.Error && (previous?.State != PrinterState.Error || !SequenceEqual(previous?.HmsCodes, current.HmsCodes)))
+        {
+            string description = HmsResolver.Description(current.HmsCodes, printer.Serial, pl)
+                ?? (current.ErrorCode != 0
+                    ? string.Format(AppSettings.Text("Kod błędu: 0x{0:X}", "Error code: 0x{0:X}"), current.ErrorCode)
+                    : AppSettings.Text("Drukarka zgłosiła błąd.", "The printer reported an error."));
+            NotificationService.Post(AppSettings.Text("Błąd drukarki", "Printer error"), description, printer.Name);
+        }
+        else if (current.State == PrinterState.Paused && previous?.State != PrinterState.Paused)
+        {
+            NotificationService.Post(AppSettings.Text("Druk wstrzymany", "Print paused"),
+                current.JobName ?? AppSettings.Text("Drukarka oczekuje na działanie.", "The printer needs attention."), printer.Name);
+        }
+
+        var previousLow = new HashSet<string>((previous?.AmsSlots ?? new()).Where(s => (s.RemainingPercent ?? 100) <= 15).Select(s => s.Id));
+        var newLow = current.AmsSlots.Where(s => (s.RemainingPercent ?? 100) <= 15 && !previousLow.Contains(s.Id)).ToList();
+        if (newLow.FirstOrDefault() is { } slot)
+            NotificationService.Post(AppSettings.Text("Niski poziom filamentu", "Low filament"),
+                $"{slot.Label} • {slot.Material} • {slot.RemainingPercent ?? 0}%", printer.Name);
+
+        if (IsHumidityHigh(current.AmsHumidity) && !IsHumidityHigh(previous?.AmsHumidity))
+            NotificationService.Post(AppSettings.Text("Wysoka wilgotność AMS", "High AMS humidity"),
+                AppSettings.Text("Sprawdź lub osusz pochłaniacz wilgoci.", "Check or dry the desiccant."), printer.Name);
+    }
+
+    private static bool IsHumidityHigh(int? value)
+    {
+        if (value is null) return false;
+        return value <= 5 ? value >= 4 : value >= 40;
+    }
+
+    private static bool SequenceEqual(List<string>? a, List<string> b)
+        => a is not null && a.Count == b.Count && a.SequenceEqual(b);
+
+    private sealed class NumericHostComparer : IComparer<string>
+    {
+        public int Compare(string? x, string? y)
+        {
+            System.Net.IPAddress.TryParse(x, out var a);
+            System.Net.IPAddress.TryParse(y, out var b);
+            var ab = a?.GetAddressBytes();
+            var bb = b?.GetAddressBytes();
+            if (ab is null || bb is null) return string.CompareOrdinal(x, y);
+            for (int i = 0; i < Math.Min(ab.Length, bb.Length); i++)
+                if (ab[i] != bb[i]) return ab[i].CompareTo(bb[i]);
+            return 0;
+        }
+    }
+}

--- a/windows/BambuBar.Windows/Services/SsdpDiscovery.cs
+++ b/windows/BambuBar.Windows/Services/SsdpDiscovery.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using BambuBar.Models;
+
+namespace BambuBar.Services;
+
+/// <summary>SSDP multicast discovery of Bambu printers, ported from the macOS SSDPDiscovery.</summary>
+public sealed class SsdpDiscovery
+{
+    private static readonly IPAddress Multicast = IPAddress.Parse("239.255.255.250");
+
+    public async Task<List<DiscoveredPrinter>> ScanAsync(double seconds = 4)
+    {
+        var found = new Dictionary<string, DiscoveredPrinter>();
+        UdpClient? udp = null;
+        try
+        {
+            udp = new UdpClient();
+            udp.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            // Prefer UDP 2021 (Bambu's announcement port). If it is already held — e.g. Bambu
+            // Studio is running and doesn't permit sharing — fall back to an ephemeral port; the
+            // unicast replies to our M-SEARCH still arrive.
+            try
+            {
+                udp.Client.Bind(new IPEndPoint(IPAddress.Any, 2021));
+            }
+            catch (SocketException)
+            {
+                System.Diagnostics.Debug.WriteLine("SSDP port 2021 unavailable, using an ephemeral port");
+                udp.Client.Bind(new IPEndPoint(IPAddress.Any, 0));
+            }
+            try { udp.JoinMulticastGroup(Multicast); } catch { /* interface without multicast */ }
+
+            var message = Encoding.ASCII.GetBytes(
+                "M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1900\r\nMAN: \"ssdp:discover\"\r\nMX: 2\r\nST: urn:bambulab-com:device:3dprinter:1\r\n\r\n");
+            try { await udp.SendAsync(message, message.Length, new IPEndPoint(Multicast, 1900)); } catch { }
+
+            using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(seconds));
+            while (!deadline.IsCancellationRequested)
+            {
+                UdpReceiveResult result;
+                try { result = await udp.ReceiveAsync(deadline.Token); }
+                catch (OperationCanceledException) { break; }
+                catch { break; }
+
+                var printer = SsdpResponseParser.Parse(result.Buffer, result.RemoteEndPoint.Address.ToString());
+                if (printer is not null) found[printer.Serial] = printer;
+            }
+        }
+        catch { /* return whatever we have */ }
+        finally { udp?.Dispose(); }
+
+        return found.Values
+            .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/windows/BambuBar.Windows/Services/SsdpResponseParser.cs
+++ b/windows/BambuBar.Windows/Services/SsdpResponseParser.cs
@@ -1,0 +1,61 @@
+using System.Text;
+using BambuBar.Models;
+
+namespace BambuBar.Services;
+
+/// <summary>Parses an SSDP advertisement into a DiscoveredPrinter, ported from the macOS parser.</summary>
+public static class SsdpResponseParser
+{
+    public static DiscoveredPrinter? Parse(byte[] data, string? fallbackHost = null)
+    {
+        string text;
+        try { text = Encoding.UTF8.GetString(data); }
+        catch { return null; }
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in text.Split('\n', '\r'))
+        {
+            int colon = line.IndexOf(':');
+            if (colon < 0) continue;
+            string key = line[..colon].Trim().ToLowerInvariant();
+            string value = line[(colon + 1)..].Trim();
+            headers[key] = value;
+        }
+
+        string rawSerial = Value(headers, "usn", "devserial.bambu.com", "serial-number")
+            .Replace("uuid:", "", StringComparison.OrdinalIgnoreCase);
+        string serial = rawSerial.Split(new[] { "::" }, 2, StringSplitOptions.None)[0];
+        if (string.IsNullOrEmpty(serial)) return null;
+
+        string location = Value(headers, "location");
+        string host = HostFrom(location) ?? fallbackHost ?? "";
+        if (string.IsNullOrEmpty(host)) return null;
+
+        string name = Value(headers, "devname.bambu.com", "friendlyname", "name");
+        string model = Value(headers, "devmodel.bambu.com", "modelname", "model");
+        string suffix = serial.Length >= 4 ? serial[^4..] : serial;
+        return new DiscoveredPrinter
+        {
+            Serial = serial,
+            Name = string.IsNullOrEmpty(name) ? $"Bambu {suffix}" : name,
+            Model = string.IsNullOrEmpty(model) ? "Bambu Lab" : model,
+            Host = host
+        };
+    }
+
+    private static string Value(Dictionary<string, string> headers, params string[] keys)
+    {
+        foreach (var key in keys)
+            if (headers.TryGetValue(key, out var v) && !string.IsNullOrEmpty(v))
+                return v;
+        return "";
+    }
+
+    private static string? HostFrom(string location)
+    {
+        if (Uri.TryCreate(location, UriKind.Absolute, out var url) && !string.IsNullOrEmpty(url.Host))
+            return url.Host;
+        var trimmed = location.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+}

--- a/windows/BambuBar.Windows/Services/StatusParser.cs
+++ b/windows/BambuBar.Windows/Services/StatusParser.cs
@@ -1,0 +1,208 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using BambuBar.Models;
+
+namespace BambuBar.Services;
+
+/// <summary>Parses Bambu MQTT telemetry JSON, ported 1:1 from the macOS BambuStatusParser.</summary>
+public static class StatusParser
+{
+    public static PrinterTelemetry? Telemetry(byte[] data, PrinterTelemetry? previous = null)
+    {
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            root = doc.RootElement.Clone();
+        }
+        catch { return null; }
+
+        if (root.ValueKind != JsonValueKind.Object) return null;
+        JsonElement report;
+        if (root.TryGetProperty("print", out var p)) report = p;
+        else if (root.TryGetProperty("pushing", out var pu)) report = pu;
+        else return null;
+        if (report.ValueKind != JsonValueKind.Object) return null;
+
+        var result = previous?.Clone() ?? new PrinterTelemetry();
+
+        if (Str(report, "gcode_state") is { } state) result.State = MapState(state);
+        if (Int(report, "mc_percent") is { } percent) result.Progress = Math.Min(Math.Max(percent, 0), 100);
+        if (Int(report, "mc_remaining_time") is { } rem) result.RemainingMinutes = rem;
+        if (Num(report, "nozzle_temper") is { } nt) result.NozzleTemperature = nt;
+        if (Num(report, "nozzle_target_temper") is { } ntt) result.NozzleTargetTemperature = ntt;
+        if (Num(report, "bed_temper") is { } bt) result.BedTemperature = bt;
+        if (Num(report, "bed_target_temper") is { } btt) result.BedTargetTemperature = btt;
+        if (Num(report, "chamber_temper") is { } ct) result.ChamberTemperature = ct;
+        if (Int(report, "layer_num") is { } ln) result.CurrentLayer = ln;
+        if (Int(report, "total_layer_num") is { } tln) result.TotalLayers = tln;
+
+        if (report.TryGetProperty("stage", out var stage) && stage.ValueKind == JsonValueKind.Object && Int(stage, "_id") is { } sid)
+            result.CurrentStage = sid;
+        else if (Int(report, "stg_cur") is { } stg)
+            result.CurrentStage = stg;
+
+        if ((Str(report, "print_type")?.ToLowerInvariant() == "idle") && result.CurrentStage == 0)
+            result.CurrentStage = 255;
+
+        if (Str(report, "subtask_name") is { Length: > 0 } job) result.JobName = DisplayName(job);
+        if (UInt64Value(report, "print_error") is { } err) result.ErrorCode = err;
+
+        if (report.TryGetProperty("hms", out var hms) && hms.ValueKind == JsonValueKind.Array)
+        {
+            var codes = new List<string>();
+            foreach (var item in hms.EnumerateArray())
+                if (HmsCode(item) is { } code) codes.Add(code);
+            result.HmsCodes = codes;
+        }
+
+        if (report.TryGetProperty("ams", out var ams) && ams.ValueKind == JsonValueKind.Object)
+        {
+            var (slots, humidity, temperature) = ParseAms(ams);
+            result.AmsSlots = slots;
+            result.AmsHumidity = humidity;
+            result.AmsTemperature = temperature;
+        }
+
+        if (result.ErrorCode != 0) result.State = PrinterState.Error;
+        result.LastUpdated = DateTime.Now;
+        return result;
+    }
+
+    public static PrinterState MapState(string raw) => raw.ToUpperInvariant() switch
+    {
+        "RUNNING" or "PREPARE" => PrinterState.Printing,
+        "PAUSE" or "PAUSED" => PrinterState.Paused,
+        "FINISH" or "FINISHED" => PrinterState.Finished,
+        "FAILED" or "ERROR" => PrinterState.Error,
+        "IDLE" => PrinterState.Idle,
+        _ => PrinterState.Idle
+    };
+
+    private static string DisplayName(string raw)
+    {
+        string value = Uri.UnescapeDataString(raw);
+        if (value.Contains('Ã') || value.Contains('Å') || value.Contains('Ä'))
+        {
+            try
+            {
+                var bytes = Encoding.GetEncoding(1252).GetBytes(value);
+                value = Encoding.UTF8.GetString(bytes);
+            }
+            catch { /* keep original */ }
+        }
+        return value.Normalize(NormalizationForm.FormC);
+    }
+
+    private static (List<AmsSlot> Slots, int? Humidity, double? Temperature) ParseAms(JsonElement ams)
+    {
+        string activeRaw = Str(ams, "tray_now") ?? Int(ams, "tray_now")?.ToString() ?? "";
+        var slots = new List<AmsSlot>();
+        int? humidity = null;
+        double? temperature = null;
+
+        if (ams.TryGetProperty("ams", out var units) && units.ValueKind == JsonValueKind.Array)
+        {
+            int unitIndex = 0;
+            foreach (var unit in units.EnumerateArray())
+            {
+                humidity ??= Int(unit, "humidity_raw") ?? Int(unit, "humidity");
+                temperature ??= Num(unit, "temp");
+                string unitId = Str(unit, "id") ?? unitIndex.ToString();
+                string unitLetter = ((char)(65 + Math.Min(unitIndex, 25))).ToString();
+                var trays = unit.TryGetProperty("tray", out var t) && t.ValueKind == JsonValueKind.Array
+                    ? t.EnumerateArray().ToList()
+                    : new List<JsonElement>();
+                // A single-spool AMS reports itself as unit 128; a regular AMS owns four fixed positions.
+                int slotCount = unitId == "128" ? 1 : 4;
+                for (int trayIndex = 0; trayIndex < slotCount; trayIndex++)
+                {
+                    JsonElement tray = trayIndex < trays.Count ? trays[trayIndex] : default;
+                    bool hasTray = trayIndex < trays.Count;
+                    string trayId = (hasTray ? (Str(tray, "id") ?? Int(tray, "id")?.ToString()) : null) ?? trayIndex.ToString();
+                    string material = (hasTray ? (Str(tray, "tray_type") ?? Str(tray, "tray_sub_brands")) : null) ?? "";
+                    string color = material.Length == 0 ? "8E8E93FF" : ((hasTray ? Str(tray, "tray_color") : null) ?? "8E8E93FF");
+                    int globalIndex = unitIndex * 4 + trayIndex;
+                    bool isActive = activeRaw == globalIndex.ToString() || activeRaw == $"{unitId}{trayId}";
+                    slots.Add(new AmsSlot
+                    {
+                        Id = $"ams-{unitId}-{trayId}",
+                        Label = $"{unitLetter}{trayIndex + 1}",
+                        Material = material.Length == 0 ? "—" : material,
+                        ColorHex = color,
+                        RemainingPercent = material.Length == 0 ? null : (hasTray ? Int(tray, "remain") : null),
+                        IsActive = isActive,
+                        IsExternal = false
+                    });
+                }
+                unitIndex++;
+            }
+        }
+
+        if (ams.TryGetProperty("vt_tray", out var external) && external.ValueKind == JsonValueKind.Object)
+        {
+            string material = Str(external, "tray_type") ?? Str(external, "tray_sub_brands") ?? "";
+            if (material.Length > 0)
+            {
+                string trayId = Str(external, "id") ?? "254";
+                slots.Add(new AmsSlot
+                {
+                    Id = $"external-{trayId}",
+                    Label = "EXT",
+                    Material = material,
+                    ColorHex = Str(external, "tray_color") ?? "E8E8E8FF",
+                    RemainingPercent = Int(external, "remain"),
+                    IsActive = activeRaw == trayId || activeRaw == "254" || activeRaw == "255",
+                    IsExternal = true
+                });
+            }
+        }
+
+        return (slots, humidity, temperature);
+    }
+
+    private static string? HmsCode(JsonElement item)
+    {
+        if (UInt64Value(item, "code") is not { } code) return null;
+        ulong attr = UInt64Value(item, "attr") ?? 0;
+        if (attr == 0 && Str(item, "ecode") is { Length: > 0 } raw)
+            return raw.Replace("_", "").ToUpperInvariant();
+        return $"{attr:X8}{code:X8}";
+    }
+
+    private static string? Str(JsonElement obj, string key)
+        => obj.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static double? Num(JsonElement obj, string key)
+    {
+        if (!obj.TryGetProperty(key, out var v)) return null;
+        if (v.ValueKind == JsonValueKind.Number && v.TryGetDouble(out var d)) return d;
+        if (v.ValueKind == JsonValueKind.String && double.TryParse(v.GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var ds)) return ds;
+        return null;
+    }
+
+    private static int? Int(JsonElement obj, string key)
+    {
+        var n = Num(obj, key);
+        return n.HasValue ? (int)n.Value : null;
+    }
+
+    private static ulong? UInt64Value(JsonElement obj, string key)
+    {
+        if (!obj.TryGetProperty(key, out var v)) return null;
+        if (v.ValueKind == JsonValueKind.Number)
+        {
+            if (v.TryGetUInt64(out var u)) return u;
+            if (v.TryGetDouble(out var d)) return (ulong)d;
+        }
+        if (v.ValueKind == JsonValueKind.String)
+        {
+            string s = v.GetString() ?? "";
+            if (ulong.TryParse(s, out var dec)) return dec;
+            string hex = s.Replace("0x", "");
+            if (ulong.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var h)) return h;
+        }
+        return null;
+    }
+}

--- a/windows/BambuBar.Windows/Services/Storage.cs
+++ b/windows/BambuBar.Windows/Services/Storage.cs
@@ -1,0 +1,186 @@
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using BambuBar.Models;
+
+namespace BambuBar.Services;
+
+/// <summary>
+/// Key/value store persisted to %AppData%\BambuBar\defaults.json — the Windows equivalent
+/// of the macOS UserDefaults suite used across the app.
+/// </summary>
+public static class Defaults
+{
+    private static readonly object Gate = new();
+    private static readonly string Dir =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "BambuBar");
+    private static readonly string FilePath = Path.Combine(Dir, "defaults.json");
+    private static Dictionary<string, JsonElement> _store = Load();
+
+    private static Dictionary<string, JsonElement> Load()
+    {
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                using var doc = JsonDocument.Parse(File.ReadAllText(FilePath));
+                var dict = new Dictionary<string, JsonElement>();
+                foreach (var prop in doc.RootElement.EnumerateObject())
+                    dict[prop.Name] = prop.Value.Clone();
+                return dict;
+            }
+        }
+        catch { /* fall through to empty */ }
+        return new Dictionary<string, JsonElement>();
+    }
+
+    private static void Persist()
+    {
+        try
+        {
+            Directory.CreateDirectory(Dir);
+            using var stream = File.Create(FilePath);
+            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+            writer.WriteStartObject();
+            foreach (var kv in _store)
+            {
+                writer.WritePropertyName(kv.Key);
+                kv.Value.WriteTo(writer);
+            }
+            writer.WriteEndObject();
+        }
+        catch { /* best effort */ }
+    }
+
+    private static JsonElement Wrap(object value)
+        => JsonSerializer.SerializeToElement(value);
+
+    public static string? GetString(string key)
+        => _store.TryGetValue(key, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    public static void SetString(string key, string value)
+    {
+        lock (Gate) { _store[key] = Wrap(value); Persist(); }
+    }
+
+    public static bool GetBool(string key, bool fallback = false)
+        => _store.TryGetValue(key, out var v) && (v.ValueKind == JsonValueKind.True || v.ValueKind == JsonValueKind.False)
+            ? v.GetBoolean() : fallback;
+
+    public static void SetBool(string key, bool value)
+    {
+        lock (Gate) { _store[key] = Wrap(value); Persist(); }
+    }
+
+    public static Dictionary<string, string> GetStringDictionary(string key)
+    {
+        if (_store.TryGetValue(key, out var v) && v.ValueKind == JsonValueKind.Object)
+        {
+            var dict = new Dictionary<string, string>();
+            foreach (var prop in v.EnumerateObject())
+                if (prop.Value.ValueKind == JsonValueKind.String)
+                    dict[prop.Name] = prop.Value.GetString()!;
+            return dict;
+        }
+        return new Dictionary<string, string>();
+    }
+
+    public static void SetStringDictionary(string key, Dictionary<string, string> value)
+    {
+        lock (Gate) { _store[key] = Wrap(value); Persist(); }
+    }
+
+    public static string? GetRaw(string key)
+        => _store.TryGetValue(key, out var v) ? v.GetRawText() : null;
+
+    public static void SetRaw(string key, string json)
+    {
+        lock (Gate)
+        {
+            using var doc = JsonDocument.Parse(json);
+            _store[key] = doc.RootElement.Clone();
+            Persist();
+        }
+    }
+}
+
+/// <summary>User-facing settings mirroring the macOS AppSettings.</summary>
+public static class AppSettings
+{
+    public static bool Polish
+    {
+        get => (Defaults.GetString("app-language") ?? DefaultLanguage()) == "pl";
+        set => Defaults.SetString("app-language", value ? "pl" : "en");
+    }
+
+    public static bool CompactMode
+    {
+        get => Defaults.GetBool("dashboard-compact-mode");
+        set => Defaults.SetBool("dashboard-compact-mode", value);
+    }
+
+    public static string Text(string polish, string english) => Polish ? polish : english;
+
+    private static string DefaultLanguage()
+        => System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "pl" ? "pl" : "en";
+}
+
+/// <summary>Persists the configured printer list (saved-printers-v1), same schema as macOS.</summary>
+public static class SavedPrinterStore
+{
+    private const string Key = "saved-printers-v1";
+
+    public static List<SavedPrinter> Load()
+    {
+        var raw = Defaults.GetRaw(Key);
+        if (raw is null) return new List<SavedPrinter>();
+        try { return JsonSerializer.Deserialize<List<SavedPrinter>>(raw) ?? new(); }
+        catch { return new List<SavedPrinter>(); }
+    }
+
+    public static void Save(List<SavedPrinter> printers)
+        => Defaults.SetRaw(Key, JsonSerializer.Serialize(printers));
+}
+
+/// <summary>
+/// Stores each printer access code encrypted with Windows DPAPI (per-user) — the Windows
+/// counterpart of the macOS Keychain. Encrypted blobs live in defaults under a dedicated key.
+/// </summary>
+public static class AccessCodeStore
+{
+    public const string ModeName = "DPAPI";
+    private const string Key = "printer-access-codes-dpapi-v1";
+    private static readonly byte[] Entropy = Encoding.UTF8.GetBytes("pl.bambubar.access-code.v1");
+
+    public static void Save(string accessCode, string serial)
+    {
+        if (string.IsNullOrEmpty(accessCode)) throw new ArgumentException("empty access code");
+        var protectedBytes = ProtectedData.Protect(Encoding.UTF8.GetBytes(accessCode), Entropy, DataProtectionScope.CurrentUser);
+        var dict = Defaults.GetStringDictionary(Key);
+        dict[serial] = Convert.ToBase64String(protectedBytes);
+        Defaults.SetStringDictionary(Key, dict);
+    }
+
+    public static string? AccessCode(string serial)
+    {
+        var dict = Defaults.GetStringDictionary(Key);
+        if (!dict.TryGetValue(serial, out var stored)) return null;
+        try
+        {
+            var bytes = ProtectedData.Unprotect(Convert.FromBase64String(stored), Entropy, DataProtectionScope.CurrentUser);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        catch { return null; }
+    }
+
+    public static string ReadAccessCode(string serial)
+        => AccessCode(serial) ?? throw new InvalidOperationException(
+            AppSettings.Text("Brak zapisanego kodu dostępu.", "No stored access code."));
+
+    public static void Delete(string serial)
+    {
+        var dict = Defaults.GetStringDictionary(Key);
+        if (dict.Remove(serial)) Defaults.SetStringDictionary(Key, dict);
+    }
+}

--- a/windows/BambuBar.Windows/Services/SubnetDiscovery.cs
+++ b/windows/BambuBar.Windows/Services/SubnetDiscovery.cs
@@ -1,0 +1,117 @@
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Net.NetworkInformation;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using BambuBar.Models;
+
+namespace BambuBar.Services;
+
+/// <summary>
+/// Finds Bambu printers even when multicast is filtered: a Bambu MQTTs certificate exposes the
+/// serial number as its subject CN. Ported from the macOS BambuSubnetDiscovery.
+/// </summary>
+public sealed class SubnetDiscovery
+{
+    public async Task<List<DiscoveredPrinter>> ScanAsync()
+    {
+        var prefixes = LocalIPv4Prefixes();
+        if (prefixes.Count == 0) return new List<DiscoveredPrinter>();
+
+        var hosts = prefixes
+            .SelectMany(prefix => Enumerable.Range(1, 254).Select(i => $"{prefix}.{i}"))
+            .Distinct()
+            .ToList();
+
+        var found = new Dictionary<string, DiscoveredPrinter>();
+        var gate = new object();
+        using var limiter = new SemaphoreSlim(128);
+
+        var tasks = hosts.Select(async host =>
+        {
+            await limiter.WaitAsync();
+            try
+            {
+                var printer = await ProbeAsync(host);
+                if (printer is not null)
+                    lock (gate) found[printer.Serial] = printer;
+            }
+            finally { limiter.Release(); }
+        });
+        await Task.WhenAll(tasks);
+
+        return found.Values
+            .OrderBy(p => p.Host, new HostComparer())
+            .ToList();
+    }
+
+    private static async Task<DiscoveredPrinter?> ProbeAsync(string host)
+    {
+        string? serial = null;
+        TcpClient? tcp = null;
+        SslStream? ssl = null;
+        try
+        {
+            tcp = new TcpClient();
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2.0));
+            await tcp.ConnectAsync(host, 8883, timeout.Token);
+            ssl = new SslStream(tcp.GetStream(), false, (_, certificate, _, _) =>
+            {
+                if (certificate is X509Certificate cert)
+                {
+                    var x = new X509Certificate2(cert);
+                    serial = x.GetNameInfo(X509NameType.SimpleName, false)?.Trim();
+                }
+                return true;
+            });
+            await ssl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions { TargetHost = host }, timeout.Token);
+        }
+        catch { /* not a printer / unreachable */ }
+        finally
+        {
+            try { ssl?.Dispose(); } catch { }
+            try { tcp?.Close(); } catch { }
+        }
+
+        if (serial is null || serial.Length < 10 || !serial.All(char.IsLetterOrDigit)) return null;
+        return new DiscoveredPrinter
+        {
+            Serial = serial,
+            Name = $"Bambu {serial[^4..]}",
+            Model = "Bambu Lab",
+            Host = host
+        };
+    }
+
+    private static List<string> LocalIPv4Prefixes()
+    {
+        var prefixes = new HashSet<string>();
+        foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (ni.OperationalStatus != OperationalStatus.Up) continue;
+            if (ni.NetworkInterfaceType == NetworkInterfaceType.Loopback) continue;
+            foreach (var addr in ni.GetIPProperties().UnicastAddresses)
+            {
+                if (addr.Address.AddressFamily != AddressFamily.InterNetwork) continue;
+                var parts = addr.Address.ToString().Split('.');
+                if (parts.Length == 4) prefixes.Add(string.Join('.', parts.Take(3)));
+            }
+        }
+        return prefixes.ToList();
+    }
+
+    private sealed class HostComparer : IComparer<string>
+    {
+        public int Compare(string? x, string? y)
+        {
+            IPAddress.TryParse(x, out var a);
+            IPAddress.TryParse(y, out var b);
+            var ab = a?.GetAddressBytes();
+            var bb = b?.GetAddressBytes();
+            if (ab is null || bb is null) return string.CompareOrdinal(x, y);
+            for (int i = 0; i < 4; i++)
+                if (ab[i] != bb[i]) return ab[i].CompareTo(bb[i]);
+            return 0;
+        }
+    }
+}

--- a/windows/BambuBar.Windows/UI/AddPrinterWindow.xaml
+++ b/windows/BambuBar.Windows/UI/AddPrinterWindow.xaml
@@ -1,0 +1,44 @@
+<Window x:Class="BambuBar.UI.AddPrinterWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="BambuBar" Width="420" Height="560"
+        WindowStartupLocation="CenterOwner"
+        Background="#FF1C1C1E" Foreground="#FFF5F5F7"
+        FontFamily="Segoe UI" ResizeMode="NoResize" ShowInTaskbar="False">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="16">
+            <TextBlock x:Name="Heading" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,10"/>
+
+            <StackPanel x:Name="DiscoverySection">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock x:Name="DetectedLabel" VerticalAlignment="Center" Foreground="#FF9A9A9E"/>
+                    <Button Grid.Column="1" x:Name="ScanButton" Content="⟳" Width="34" Height="26"/>
+                </Grid>
+                <ListBox x:Name="DetectedList" Height="110" Margin="0,6,0,6"
+                         Background="#FF2C2C2E" Foreground="#FFF5F5F7" BorderThickness="0"/>
+                <Button x:Name="ImportButton" Height="28" Margin="0,0,0,8"/>
+                <Separator Margin="0,4,0,10"/>
+            </StackPanel>
+
+            <TextBlock x:Name="NameLabel" Margin="0,4,0,2"/>
+            <TextBox x:Name="NameBox" Height="26" Background="#FF2C2C2E" Foreground="#FFF5F5F7" BorderThickness="0" Padding="6,3"/>
+            <TextBlock x:Name="HostLabel" Margin="0,8,0,2"/>
+            <TextBox x:Name="HostBox" Height="26" Background="#FF2C2C2E" Foreground="#FFF5F5F7" BorderThickness="0" Padding="6,3"/>
+            <TextBlock x:Name="SerialLabel" Margin="0,8,0,2"/>
+            <TextBox x:Name="SerialBox" Height="26" Background="#FF2C2C2E" Foreground="#FFF5F5F7" BorderThickness="0" Padding="6,3"/>
+            <TextBlock x:Name="CodeLabel" Margin="0,8,0,2"/>
+            <TextBox x:Name="CodeBox" Height="26" Background="#FF2C2C2E" Foreground="#FFF5F5F7" BorderThickness="0" Padding="6,3"/>
+
+            <TextBlock x:Name="ErrorText" Foreground="#FFFF453A" TextWrapping="Wrap" Margin="0,10,0,0" Visibility="Collapsed"/>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+                <Button x:Name="CancelButton" Width="90" Height="30" Margin="0,0,8,0"/>
+                <Button x:Name="SaveButton" Width="110" Height="30"/>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Window>

--- a/windows/BambuBar.Windows/UI/AddPrinterWindow.xaml.cs
+++ b/windows/BambuBar.Windows/UI/AddPrinterWindow.xaml.cs
@@ -1,0 +1,125 @@
+using System.Windows;
+using System.Windows.Controls;
+using BambuBar.Models;
+using BambuBar.Services;
+
+namespace BambuBar.UI;
+
+public partial class AddPrinterWindow : Window
+{
+    private readonly PrinterStore _store;
+    private readonly SavedPrinter? _editing;
+
+    public AddPrinterWindow(PrinterStore store, SavedPrinter? editing = null)
+    {
+        InitializeComponent();
+        _store = store;
+        _editing = editing;
+
+        Localize();
+
+        if (editing is not null)
+        {
+            DiscoverySection.Visibility = Visibility.Collapsed;
+            NameBox.Text = editing.Name;
+            HostBox.Text = editing.Host;
+            SerialBox.Text = editing.Serial;
+            CodeBox.Text = "";
+        }
+
+        ScanButton.Click += (_, _) => _store.Scan();
+        ImportButton.Click += (_, _) => ImportFromStudio();
+        SaveButton.Click += (_, _) => Save();
+        CancelButton.Click += (_, _) => Close();
+        DetectedList.SelectionChanged += OnDetectedSelected;
+
+        _store.Updated += OnStoreUpdated;
+        Closed += (_, _) => _store.Updated -= OnStoreUpdated;
+        RefreshDetected();
+    }
+
+    private void Localize()
+    {
+        Title = _editing is null ? AppSettings.Text("Dodaj drukarkę", "Add printer") : AppSettings.Text("Edytuj drukarkę", "Edit printer");
+        Heading.Text = Title;
+        DetectedLabel.Text = AppSettings.Text("Wykryte drukarki", "Detected printers");
+        ImportButton.Content = AppSettings.Text("Importuj z Bambu Studio", "Import from Bambu Studio");
+        NameLabel.Text = AppSettings.Text("Nazwa (opcjonalnie)", "Name (optional)");
+        HostLabel.Text = AppSettings.Text("Adres IP", "IP address");
+        SerialLabel.Text = AppSettings.Text("Numer seryjny", "Serial number");
+        CodeLabel.Text = AppSettings.Text("Kod dostępu (Access Code / PIN)", "Access Code / PIN");
+        CancelButton.Content = AppSettings.Text("Anuluj", "Cancel");
+        SaveButton.Content = _editing is null ? AppSettings.Text("Dodaj", "Add") : AppSettings.Text("Zapisz", "Save");
+    }
+
+    private void OnStoreUpdated(object? sender, EventArgs e) => Dispatcher.Invoke(RefreshDetected);
+
+    private void RefreshDetected()
+    {
+        if (_editing is not null) return;
+        var selectedSerial = (DetectedList.SelectedItem as DiscoveredItem)?.Printer.Serial;
+        DetectedList.Items.Clear();
+        foreach (var d in _store.Discovered)
+            DetectedList.Items.Add(new DiscoveredItem(d));
+        DetectedLabel.Text = _store.IsScanning
+            ? AppSettings.Text("Skanowanie…", "Scanning…")
+            : AppSettings.Text($"Wykryte drukarki ({_store.Discovered.Count})", $"Detected printers ({_store.Discovered.Count})");
+        if (selectedSerial is not null)
+            foreach (DiscoveredItem item in DetectedList.Items)
+                if (item.Printer.Serial == selectedSerial) { DetectedList.SelectedItem = item; break; }
+    }
+
+    private void OnDetectedSelected(object? sender, SelectionChangedEventArgs e)
+    {
+        if (DetectedList.SelectedItem is DiscoveredItem item)
+        {
+            NameBox.Text = item.Printer.Name;
+            HostBox.Text = item.Printer.Host;
+            SerialBox.Text = item.Printer.Serial;
+            CodeBox.Focus();
+        }
+    }
+
+    private void ImportFromStudio()
+    {
+        try
+        {
+            int count = _store.ImportFromBambuStudio();
+            MessageBox.Show(this, AppSettings.Text($"Zaimportowano drukarek: {count}", $"Imported printers: {count}"), "BambuBar");
+            Close();
+        }
+        catch (Exception ex)
+        {
+            ShowError(ex.Message);
+        }
+    }
+
+    private void Save()
+    {
+        try
+        {
+            if (_editing is not null)
+                _store.Update(_editing.Serial, NameBox.Text, SerialBox.Text, HostBox.Text, CodeBox.Text);
+            else
+                _store.AddManually(NameBox.Text, SerialBox.Text, HostBox.Text, CodeBox.Text);
+            Close();
+        }
+        catch (Exception ex)
+        {
+            ShowError(ex.Message);
+        }
+    }
+
+    private void ShowError(string message)
+    {
+        ErrorText.Text = message;
+        ErrorText.Visibility = Visibility.Visible;
+    }
+
+    private sealed class DiscoveredItem
+    {
+        public DiscoveredPrinter Printer { get; }
+        public DiscoveredItem(DiscoveredPrinter printer) => Printer = printer;
+        public override string ToString() => $"{Printer.Name}  —  {Printer.Host}  ({Printer.Serial})";
+    }
+}

--- a/windows/BambuBar.Windows/UI/DashboardWindow.xaml
+++ b/windows/BambuBar.Windows/UI/DashboardWindow.xaml
@@ -1,0 +1,29 @@
+<Window x:Class="BambuBar.UI.DashboardWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="BambuBar" Width="540" Height="660"
+        WindowStartupLocation="CenterScreen"
+        Background="#FF1C1C1E" Foreground="#FFF5F5F7"
+        FontFamily="Segoe UI" ShowInTaskbar="True">
+    <DockPanel>
+        <Border DockPanel.Dock="Top" Background="#FF2C2C2E" Padding="14,10">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="BambuBar" FontSize="17" FontWeight="SemiBold"/>
+                    <TextBlock x:Name="StatusLine" FontSize="11" Foreground="#FF9A9A9E" Margin="0,2,0,0"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                    <Button x:Name="ScanButton" Content="⟳" Width="34" Height="28" Margin="4,0" ToolTip="Scan"/>
+                    <Button x:Name="AddButton" Content="+" Width="34" Height="28" Margin="4,0" FontSize="16" ToolTip="Add printer"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="10">
+            <WrapPanel x:Name="CardsPanel" Orientation="Horizontal"/>
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/windows/BambuBar.Windows/UI/DashboardWindow.xaml.cs
+++ b/windows/BambuBar.Windows/UI/DashboardWindow.xaml.cs
@@ -1,0 +1,256 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using BambuBar.Models;
+using BambuBar.Services;
+
+namespace BambuBar.UI;
+
+public partial class DashboardWindow : Window
+{
+    private readonly PrinterStore _store;
+
+    public DashboardWindow(PrinterStore store)
+    {
+        InitializeComponent();
+        _store = store;
+        ScanButton.Click += (_, _) => _store.Scan();
+        AddButton.Click += (_, _) => OpenAddWindow();
+        _store.Updated += OnStoreUpdated;
+        Closed += (_, _) => _store.Updated -= OnStoreUpdated;
+        Rebuild();
+    }
+
+    public void RefreshLanguage() => Rebuild();
+
+    private void OnStoreUpdated(object? sender, EventArgs e) => Dispatcher.Invoke(Rebuild);
+
+    private void OpenAddWindow()
+    {
+        var window = new AddPrinterWindow(_store) { Owner = this };
+        window.ShowDialog();
+    }
+
+    private void Rebuild()
+    {
+        StatusLine.Text = _store.IsScanning
+            ? AppSettings.Text("Skanowanie…", "Scanning…")
+            : (_store.GlobalMessage ?? AppSettings.Text($"{_store.Printers.Count} drukarek • {_store.ActivePrintCount} drukuje",
+                                                        $"{_store.Printers.Count} printers • {_store.ActivePrintCount} printing"));
+        CardsPanel.Children.Clear();
+
+        if (_store.Printers.Count == 0)
+        {
+            CardsPanel.Children.Add(new TextBlock
+            {
+                Text = AppSettings.Text("Brak drukarek. Kliknij +, aby dodać.", "No printers. Click + to add one."),
+                Foreground = new SolidColorBrush(Color.FromRgb(0x9A, 0x9A, 0x9E)),
+                Margin = new Thickness(8)
+            });
+        }
+
+        foreach (var printer in _store.Printers)
+            CardsPanel.Children.Add(BuildCard(printer));
+    }
+
+    private Border BuildCard(SavedPrinter printer)
+    {
+        var telemetry = _store.Telemetry.TryGetValue(printer.Serial, out var t) ? t : new PrinterTelemetry();
+        _store.ConnectionMessages.TryGetValue(printer.Serial, out var message);
+        bool pl = AppSettings.Polish;
+
+        var stack = new StackPanel();
+
+        // Header: name + state pill
+        var header = new Grid();
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        var name = new TextBlock { Text = printer.Name, FontWeight = FontWeights.SemiBold, FontSize = 14, TextTrimming = TextTrimming.CharacterEllipsis };
+        header.Children.Add(name);
+        var pill = StatePill(telemetry.State, pl);
+        Grid.SetColumn(pill, 1);
+        header.Children.Add(pill);
+        stack.Children.Add(header);
+
+        // Job name
+        stack.Children.Add(new TextBlock
+        {
+            Text = string.IsNullOrEmpty(telemetry.JobName) ? AppSettings.Text("Brak aktywnego zadania", "No active job") : telemetry.JobName!,
+            Foreground = Muted(),
+            FontSize = 11,
+            Margin = new Thickness(0, 4, 0, 6),
+            TextTrimming = TextTrimming.CharacterEllipsis
+        });
+
+        // Progress
+        var progressRow = new Grid { Margin = new Thickness(0, 0, 0, 6) };
+        progressRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        progressRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        var bar = new ProgressBar { Minimum = 0, Maximum = 100, Value = telemetry.Progress, Height = 6, Foreground = Accent(telemetry.State), Background = new SolidColorBrush(Color.FromRgb(0x3A, 0x3A, 0x3C)), BorderThickness = new Thickness(0) };
+        progressRow.Children.Add(bar);
+        var percent = new TextBlock { Text = $"{telemetry.Progress}%", FontSize = 11, Margin = new Thickness(8, 0, 0, 0), VerticalAlignment = VerticalAlignment.Center };
+        Grid.SetColumn(percent, 1);
+        progressRow.Children.Add(percent);
+        stack.Children.Add(progressRow);
+
+        // Info line: ETA + layers
+        stack.Children.Add(InfoRow(
+            (Glyph: "⏱", Value: FormatEta(telemetry.RemainingMinutes)),
+            (Glyph: "▤", Value: telemetry.CurrentLayer is { } cl && telemetry.TotalLayers is { } tl ? $"{cl}/{tl}" : "—")));
+
+        // Temps
+        stack.Children.Add(InfoRow(
+            (Glyph: "🌡", Value: FormatTemp(telemetry.NozzleTemperature, telemetry.NozzleTargetTemperature)),
+            (Glyph: "▬", Value: FormatTemp(telemetry.BedTemperature, telemetry.BedTargetTemperature))));
+
+        // AMS
+        if (telemetry.AmsSlots.Count > 0)
+        {
+            var ams = new WrapPanel { Margin = new Thickness(0, 6, 0, 0) };
+            ams.Children.Add(new TextBlock { Text = "AMS", FontSize = 10, Foreground = Muted(), Margin = new Thickness(0, 0, 6, 0), VerticalAlignment = VerticalAlignment.Center });
+            foreach (var slot in telemetry.AmsSlots)
+                ams.Children.Add(AmsChip(slot));
+            stack.Children.Add(ams);
+        }
+
+        // Connection message
+        if (!string.IsNullOrEmpty(message))
+            stack.Children.Add(new TextBlock { Text = message, FontSize = 10, Foreground = new SolidColorBrush(Color.FromRgb(0xFF, 0x9F, 0x0A)), TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 6, 0, 0) });
+
+        // Actions
+        var actions = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 8, 0, 0) };
+        actions.Children.Add(SmallButton(AppSettings.Text("Połącz", "Reconnect"), () => _store.Reconnect(printer)));
+        actions.Children.Add(SmallButton(AppSettings.Text("Edytuj", "Edit"), () =>
+        {
+            var w = new AddPrinterWindow(_store, printer) { Owner = this };
+            w.ShowDialog();
+        }));
+        actions.Children.Add(SmallButton(AppSettings.Text("Usuń", "Remove"), () =>
+        {
+            var confirm = MessageBox.Show(this,
+                AppSettings.Text($"Usunąć drukarkę {printer.Name}?", $"Remove printer {printer.Name}?"),
+                "BambuBar", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (confirm == MessageBoxResult.Yes) _store.Remove(printer);
+        }));
+        stack.Children.Add(actions);
+
+        return new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0xFF, 0x2C, 0x2C, 0x2E)),
+            CornerRadius = new CornerRadius(12),
+            Padding = new Thickness(12),
+            Margin = new Thickness(6),
+            Width = 232,
+            Child = stack
+        };
+    }
+
+    private static Border StatePill(PrinterState state, bool pl)
+    {
+        var color = ParseHex(state.AccentHex() + "FF");
+        return new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0x33, color.R, color.G, color.B)),
+            CornerRadius = new CornerRadius(6),
+            Padding = new Thickness(6, 2, 6, 2),
+            VerticalAlignment = VerticalAlignment.Center,
+            Child = new TextBlock { Text = state.Label(pl), FontSize = 10, Foreground = new SolidColorBrush(color), FontWeight = FontWeights.SemiBold }
+        };
+    }
+
+    private static Grid InfoRow((string Glyph, string Value) left, (string Glyph, string Value) right)
+    {
+        var grid = new Grid { Margin = new Thickness(0, 2, 0, 0) };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.Children.Add(Cell(left.Glyph, left.Value, 0));
+        grid.Children.Add(Cell(right.Glyph, right.Value, 1));
+        return grid;
+    }
+
+    private static StackPanel Cell(string glyph, string value, int column)
+    {
+        var panel = new StackPanel { Orientation = Orientation.Horizontal };
+        panel.Children.Add(new TextBlock { Text = glyph + " ", FontSize = 11, Foreground = Muted() });
+        panel.Children.Add(new TextBlock { Text = value, FontSize = 11 });
+        Grid.SetColumn(panel, column);
+        return panel;
+    }
+
+    private static Border AmsChip(AmsSlot slot)
+    {
+        var color = ParseHex(slot.ColorHex);
+        var border = new Border
+        {
+            Background = new SolidColorBrush(color),
+            CornerRadius = new CornerRadius(4),
+            Width = 26,
+            Height = 20,
+            Margin = new Thickness(2),
+            BorderThickness = new Thickness(slot.IsActive ? 2 : 0),
+            BorderBrush = new SolidColorBrush(Colors.White),
+            ToolTip = $"{slot.Label} • {slot.Material}" + (slot.RemainingPercent is { } r ? $" • {r}%" : "")
+        };
+        border.Child = new TextBlock
+        {
+            Text = slot.Label,
+            FontSize = 9,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = new SolidColorBrush(Luminance(color) > 0.6 ? Colors.Black : Colors.White)
+        };
+        return border;
+    }
+
+    private Button SmallButton(string text, Action onClick)
+    {
+        var button = new Button { Content = text, FontSize = 11, Margin = new Thickness(0, 0, 6, 0), Padding = new Thickness(8, 3, 8, 3) };
+        button.Click += (_, _) => onClick();
+        return button;
+    }
+
+    private static string FormatEta(int? minutes)
+    {
+        if (minutes is not { } m || m <= 0) return "—";
+        return m >= 60 ? $"{m / 60}h {m % 60}m" : $"{m}m";
+    }
+
+    private static string FormatTemp(double? current, double? target)
+    {
+        if (current is not { } c) return "—";
+        string value = c.ToString("0", CultureInfo.InvariantCulture) + "°";
+        if (target is { } t && t > 0) value += "/" + t.ToString("0", CultureInfo.InvariantCulture) + "°";
+        return value;
+    }
+
+    private static SolidColorBrush Muted() => new(Color.FromRgb(0x9A, 0x9A, 0x9E));
+    private static SolidColorBrush Accent(PrinterState state) => new(ParseHex(state.AccentHex() + "FF"));
+
+    private static Color ParseHex(string hex)
+    {
+        hex = hex.TrimStart('#');
+        try
+        {
+            if (hex.Length >= 8)
+            {
+                byte r = Convert.ToByte(hex.Substring(0, 2), 16);
+                byte g = Convert.ToByte(hex.Substring(2, 2), 16);
+                byte b = Convert.ToByte(hex.Substring(4, 2), 16);
+                byte a = Convert.ToByte(hex.Substring(6, 2), 16);
+                return Color.FromArgb(a, r, g, b);
+            }
+            if (hex.Length >= 6)
+            {
+                byte r = Convert.ToByte(hex.Substring(0, 2), 16);
+                byte g = Convert.ToByte(hex.Substring(2, 2), 16);
+                byte b = Convert.ToByte(hex.Substring(4, 2), 16);
+                return Color.FromRgb(r, g, b);
+            }
+        }
+        catch { /* fall through */ }
+        return Color.FromRgb(0x8E, 0x8E, 0x93);
+    }
+
+    private static double Luminance(Color c) => (0.299 * c.R + 0.587 * c.G + 0.114 * c.B) / 255.0;
+}

--- a/windows/BambuBar.Windows/UI/TrayIcon.cs
+++ b/windows/BambuBar.Windows/UI/TrayIcon.cs
@@ -1,0 +1,129 @@
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+using BambuBar.Services;
+using Application = System.Windows.Application;
+
+namespace BambuBar.UI;
+
+/// <summary>System tray presence — the Windows counterpart of the macOS menu bar item.</summary>
+public sealed class TrayIcon : IDisposable
+{
+    private readonly PrinterStore _store;
+    private readonly NotifyIcon _notifyIcon;
+    private DashboardWindow? _dashboard;
+
+    public TrayIcon(PrinterStore store)
+    {
+        _store = store;
+        _notifyIcon = new NotifyIcon
+        {
+            Icon = BuildIcon(),
+            Visible = true,
+            Text = "BambuBar"
+        };
+        _notifyIcon.DoubleClick += (_, _) => ShowDashboard();
+        _notifyIcon.MouseClick += (_, e) => { if (e.Button == MouseButtons.Left) ShowDashboard(); };
+        _notifyIcon.ContextMenuStrip = BuildMenu();
+        _store.Updated += (_, _) => RefreshTooltip();
+        RefreshTooltip();
+    }
+
+    private ContextMenuStrip BuildMenu()
+    {
+        var menu = new ContextMenuStrip();
+        bool pl = AppSettings.Polish;
+
+        menu.Items.Add(new ToolStripMenuItem(AppSettings.Text("Pokaż drukarki", "Show printers"), null, (_, _) => ShowDashboard()));
+        menu.Items.Add(new ToolStripMenuItem(AppSettings.Text("Szukaj drukarek…", "Scan for printers…"), null, (_, _) => { ShowDashboard(); _store.Scan(); }));
+        menu.Items.Add(new ToolStripMenuItem(AppSettings.Text("Połącz ponownie", "Reconnect all"), null, (_, _) => _store.ReconnectAll()));
+        menu.Items.Add(new ToolStripSeparator());
+
+        var language = new ToolStripMenuItem(AppSettings.Text("Język: Polski", "Language: English"));
+        language.Click += (_, _) => { AppSettings.Polish = !AppSettings.Polish; RebuildMenu(); };
+        menu.Items.Add(language);
+
+        var startup = new ToolStripMenuItem(AppSettings.Text("Uruchamiaj z Windows", "Start with Windows"))
+        {
+            Checked = LaunchAtLogin.IsEnabled,
+            CheckOnClick = true
+        };
+        startup.Click += (_, _) => LaunchAtLogin.SetEnabled(startup.Checked);
+        menu.Items.Add(startup);
+
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add(new ToolStripMenuItem(AppSettings.Text("Zakończ", "Quit"), null, (_, _) => Application.Current.Shutdown()));
+        _ = pl;
+        return menu;
+    }
+
+    private void RebuildMenu()
+    {
+        _notifyIcon.ContextMenuStrip?.Dispose();
+        _notifyIcon.ContextMenuStrip = BuildMenu();
+        _dashboard?.RefreshLanguage();
+    }
+
+    private void ShowDashboard()
+    {
+        if (_dashboard is null)
+        {
+            _dashboard = new DashboardWindow(_store);
+            _dashboard.Closed += (_, _) => _dashboard = null;
+        }
+        _dashboard.Show();
+        _dashboard.Activate();
+        _dashboard.WindowState = System.Windows.WindowState.Normal;
+    }
+
+    public void ShowNotification(string title, string body, string? subtitle)
+    {
+        string text = string.IsNullOrEmpty(subtitle) ? body : $"{subtitle}\n{body}";
+        _notifyIcon.ShowBalloonTip(5000, title, text, ToolTipIcon.Info);
+    }
+
+    private void RefreshTooltip()
+    {
+        int active = _store.ActivePrintCount;
+        int total = _store.Printers.Count;
+        _notifyIcon.Text = active > 0
+            ? AppSettings.Text($"BambuBar — {active} drukuje", $"BambuBar — {active} printing")
+            : AppSettings.Text($"BambuBar — {total} drukarek", $"BambuBar — {total} printers");
+    }
+
+    private static Icon BuildIcon()
+    {
+        using var bmp = new Bitmap(32, 32);
+        using (var g = Graphics.FromImage(bmp))
+        {
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            g.Clear(Color.Transparent);
+            using var back = new SolidBrush(Color.FromArgb(230, 28, 28, 30));
+            using var path = RoundedRect(new Rectangle(1, 1, 30, 30), 7);
+            g.FillPath(back, path);
+            using var font = new Font("Segoe UI", 12, FontStyle.Bold, GraphicsUnit.Pixel);
+            using var text = new SolidBrush(Color.FromArgb(255, 245, 245, 247));
+            var format = new StringFormat { Alignment = StringAlignment.Center, LineAlignment = StringAlignment.Center };
+            g.DrawString("BL", font, text, new RectangleF(0, 0, 32, 32), format);
+        }
+        return Icon.FromHandle(bmp.GetHicon());
+    }
+
+    private static GraphicsPath RoundedRect(Rectangle bounds, int radius)
+    {
+        int d = radius * 2;
+        var path = new GraphicsPath();
+        path.AddArc(bounds.X, bounds.Y, d, d, 180, 90);
+        path.AddArc(bounds.Right - d, bounds.Y, d, d, 270, 90);
+        path.AddArc(bounds.Right - d, bounds.Bottom - d, d, d, 0, 90);
+        path.AddArc(bounds.X, bounds.Bottom - d, d, d, 90, 90);
+        path.CloseFigure();
+        return path;
+    }
+
+    public void Dispose()
+    {
+        _notifyIcon.Visible = false;
+        _notifyIcon.Dispose();
+    }
+}

--- a/windows/BambuBar.Windows/app.manifest
+++ b/windows/BambuBar.Windows/app.manifest
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="BambuBar.app" />
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,105 @@
+# BambuBar for Windows
+
+**[English](#english)** · **[Polski](#polski)**
+
+A system-tray port of BambuBar for Windows, built with .NET 8 (WPF + WinForms tray).
+It mirrors the macOS app: local-network discovery, MQTT-over-TLS monitoring, certificate
+pinning, AMS/HMS details and notifications — no Bambu Cloud account required.
+
+---
+
+## English
+
+### Requirements
+
+- Windows 10 or 11
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) to build (end users only need the .NET 8 **Desktop Runtime**, or use the self-contained publish)
+- The Mac/PC and the printers on the same local network, LAN access enabled on each printer
+- The serial number and Access Code/PIN of each printer
+
+### Build and run
+
+```bat
+cd windows
+dotnet restore BambuBar.Windows\BambuBar.Windows.csproj
+dotnet build   BambuBar.Windows\BambuBar.Windows.csproj -c Release
+dotnet run   --project BambuBar.Windows\BambuBar.Windows.csproj
+```
+
+### Single-file executable
+
+```bat
+cd windows
+dotnet publish BambuBar.Windows\BambuBar.Windows.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false -o publish
+```
+
+The result is the self-contained `windows\publish\BambuBar.exe`, which does not require a
+separate .NET installation. The GitHub Actions workflow `.github/workflows/windows.yml`
+packages it as `BambuBar-Windows-x64.zip` on every relevant push.
+
+### How it maps to the macOS app
+
+| macOS (Swift / AppKit) | Windows (C# / .NET) |
+| --- | --- |
+| `NSStatusItem` menu bar | `NotifyIcon` tray + context menu (`UI/TrayIcon.cs`) |
+| `NWConnection` + TLS | `TcpClient` + `SslStream` (`Services/MqttClient.cs`) |
+| custom MQTT codec | `Services/MqttCodec.cs` (1:1 port) |
+| SSDP multicast discovery | `Services/SsdpDiscovery.cs` (UDP 2021 / 239.255.255.250) |
+| subnet cert-CN probe | `Services/SubnetDiscovery.cs` |
+| certificate pinning | `Services/CertificatePinStore.cs` (SHA-256) |
+| Keychain / defaults | `Services/Storage.cs` — JSON in `%AppData%\BambuBar` + DPAPI for codes |
+| status/AMS/HMS parsing | `Services/StatusParser.cs`, `Services/HmsResolver.cs` |
+| notifications | tray balloon tips (`Services/NotificationService.cs`) |
+| Launch at Login | `Services/LaunchAtLogin.cs` (HKCU Run key) |
+| SwiftUI dashboard | WPF window (`UI/DashboardWindow.xaml`) |
+
+### Storage & privacy
+
+Access codes are encrypted with Windows DPAPI (per-user) and stored under
+`%AppData%\BambuBar\defaults.json`; certificate pins and settings live in the same file.
+The app talks only to the local network. Bambu Studio codes are imported only after you
+explicitly choose **Import from Bambu Studio** (reads `%AppData%\BambuStudio\BambuStudio.conf`).
+
+---
+
+## Polski
+
+### Wymagania
+
+- Windows 10 lub 11
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) do zbudowania (użytkownik końcowy potrzebuje tylko **.NET 8 Desktop Runtime** albo wersji self-contained)
+- Komputer i drukarki w tej samej sieci lokalnej, włączony dostęp LAN na każdej drukarce
+- Numer seryjny i kod dostępu (Access Code / PIN) każdej drukarki
+
+### Budowanie i uruchamianie
+
+```bat
+cd windows
+dotnet restore BambuBar.Windows\BambuBar.Windows.csproj
+dotnet build   BambuBar.Windows\BambuBar.Windows.csproj -c Release
+dotnet run   --project BambuBar.Windows\BambuBar.Windows.csproj
+```
+
+### Pojedynczy plik .exe
+
+```bat
+cd windows
+dotnet publish BambuBar.Windows\BambuBar.Windows.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false -o publish
+```
+
+Wynik to samodzielny `windows\publish\BambuBar.exe`, który nie wymaga osobnej instalacji
+.NET. Workflow `.github/workflows/windows.yml` przy każdym odpowiednim pushu pakuje go jako
+`BambuBar-Windows-x64.zip`.
+
+### Przechowywanie i prywatność
+
+Kody dostępu są szyfrowane przez Windows DPAPI (dla użytkownika) i zapisywane w
+`%AppData%\BambuBar\defaults.json`; tam też trafiają piny certyfikatów i ustawienia.
+Aplikacja komunikuje się wyłącznie z siecią lokalną. Kody z Bambu Studio są importowane
+dopiero po świadomym wybraniu **Importuj z Bambu Studio**.
+
+### Uwaga
+
+Kompilacja jest wykonywana na Windows przez GitHub Actions. Przed oznaczeniem wersji jako
+stabilnej zalecany jest test interfejsu, zasobnika, zapory i wykrywania drukarek na fizycznym
+komputerze z Windows 10 lub 11.


### PR DESCRIPTION
## Co zmieniono

- dodano natywną aplikację BambuBar dla Windows 10/11 w C# i WPF
- dodano ikonę zasobnika, pulpit drukarek, wykrywanie SSDP/podsieci, MQTT przez TLS, AMS/HMS i powiadomienia
- kody drukarek są szyfrowane per użytkownik przez Windows DPAPI
- dodano import z lokalnej konfiguracji Bambu Studio
- dodano workflow tworzący samodzielny `BambuBar.exe` dla Windows x64 i pakujący go do ZIP

## Dlaczego

Użytkownicy Windows otrzymują odpowiednik wersji macOS, działający bez konta Bambu Cloud i bez osobnej instalacji środowiska .NET.

## Weryfikacja

- kompilacja Release na `windows-latest`
- publikacja self-contained single-file x64
- kontrola integralności ZIP
- potwierdzony format PE32+ GUI x86-64
- główny workflow projektu i workflow Windows zakończone powodzeniem

Interfejs, zasobnik, zapora i wykrywanie urządzeń wymagają jeszcze testu na fizycznym komputerze z Windows.
