### PR TITLE
Add Windows installer

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,6 +32,42 @@ jobs:
         run: .\BambuBar.Windows\bin\Release\net8.0-windows\BambuBar.exe --self-test
       - name: Publish self-contained single-file exe
         run: dotnet publish BambuBar.Windows/BambuBar.Windows.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false -o publish
+      - name: Install Inno Setup
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) {
+            choco install innosetup --yes --no-progress
+          }
+          if (-not (Test-Path $iscc)) {
+            throw "Inno Setup compiler was not found."
+          }
+      - name: Build Windows installer
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          & $iscc "installer\BambuBar.iss"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Test silent install, autostart and uninstall
+        shell: pwsh
+        run: |
+          $setup = Resolve-Path "installer-output\BambuBar-Setup-Windows-x64.exe"
+          $install = Start-Process -FilePath $setup -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-" -Wait -PassThru
+          if ($install.ExitCode -ne 0) { throw "Installer failed with exit code $($install.ExitCode)." }
+
+          $installedExe = Join-Path $env:LOCALAPPDATA "Programs\BambuBar\BambuBar.exe"
+          if (-not (Test-Path $installedExe)) { throw "Installed application was not found." }
+
+          $runValue = (Get-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "BambuBar" -ErrorAction Stop).BambuBar
+          if ($runValue -notlike "*BambuBar.exe*") { throw "Autostart registry value is invalid." }
+
+          $uninstaller = Join-Path $env:LOCALAPPDATA "Programs\BambuBar\unins000.exe"
+          $uninstall = Start-Process -FilePath $uninstaller -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART" -Wait -PassThru
+          if ($uninstall.ExitCode -ne 0) { throw "Uninstaller failed with exit code $($uninstall.ExitCode)." }
+          if (Test-Path $installedExe) { throw "Application remained after uninstall." }
+
+          $runKey = Get-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "BambuBar" -ErrorAction SilentlyContinue
+          if ($null -ne $runKey) { throw "Autostart value remained after uninstall." }
       - name: Package ZIP
         shell: pwsh
         run: Compress-Archive -Path publish/BambuBar.exe -DestinationPath publish/BambuBar-Windows-x64.zip -Force
@@ -40,4 +76,10 @@ jobs:
         with:
           name: BambuBar-Windows-x64
           path: windows/publish/BambuBar-Windows-x64.zip
+          if-no-files-found: error
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: BambuBar-Windows-Installer-x64
+          path: windows/installer-output/BambuBar-Setup-Windows-x64.exe
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Wszystkie istotne zmiany w aplikacji BambuBar są opisane w tym pliku.
 
 - dodano pierwszą wersję beta BambuBar dla 64-bitowego Windows 10 i 11, działającą jako aplikacja w zasobniku systemowym
 - wersja Windows jest publikowana jako samodzielny `BambuBar.exe` w archiwum ZIP i nie wymaga osobnej instalacji środowiska .NET
+- dodano instalator `BambuBar-Setup-Windows-x64.exe`, który nie wymaga uprawnień administratora, uruchamia aplikację po instalacji, dodaje skrót w menu Start oraz automatyczny start przy logowaniu do Windows
 - przeniesiono na Windows najważniejsze funkcje wersji macOS: wykrywanie drukarek, lokalne połączenie MQTT przez TLS, statusy druku, AMS/HMS, powiadomienia oraz import z Bambu Studio
 - kody dostępu w wersji Windows są szyfrowane dla bieżącego użytkownika za pomocą Windows DPAPI
 - poprawiono import konfiguracji Bambu Studio na Windows — obsługiwane są formaty JSON z końcową sumą kontrolną i starszy INI, również gdy Bambu Studio pozostaje otwarte

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@
 
 - [macOS Local](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-0.1.18-macOS-Local.zip)
 - [macOS Keychain](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-0.1.18-macOS-Keychain.zip)
-- [Windows x64 — self-contained beta](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-Windows-x64.zip)
+- [Windows x64 installer — beta, recommended](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-Setup-Windows-x64.exe)
+- [Windows x64 portable ZIP — beta](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-Windows-x64.zip)
 
-The Windows build does not require a separate .NET installation. / Wersja Windows nie wymaga osobnej instalacji .NET.
+The Windows installer starts BambuBar after installation and enables launch at sign-in. Neither Windows download requires a separate .NET installation. / Instalator Windows uruchamia BambuBar po instalacji i włącza start przy logowaniu. Żaden wariant Windows nie wymaga osobnej instalacji .NET.
 
 ### Windows 11 beta / Podgląd wersji beta
 

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -1,5 +1,6 @@
 bin/
 obj/
 publish/
+installer-output/
 *.user
 .vs/

--- a/windows/README.md
+++ b/windows/README.md
@@ -19,6 +19,13 @@ pinning, AMS/HMS details and notifications — no Bambu Cloud account required.
 - The Mac/PC and the printers on the same local network, LAN access enabled on each printer
 - The serial number and Access Code/PIN of each printer
 
+### Installation
+
+Download `BambuBar-Setup-Windows-x64.exe` from the latest GitHub Release. The per-user
+installer does not require administrator rights, starts BambuBar after installation and
+enables launch at Windows sign-in. It also adds a Start menu shortcut and a standard
+uninstaller. The portable ZIP remains available as an alternative.
+
 ### Build and run
 
 ```bat
@@ -72,6 +79,13 @@ explicitly choose **Import from Bambu Studio** (reads `%AppData%\BambuStudio\Bam
 - [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) do zbudowania (użytkownik końcowy potrzebuje tylko **.NET 8 Desktop Runtime** albo wersji self-contained)
 - Komputer i drukarki w tej samej sieci lokalnej, włączony dostęp LAN na każdej drukarce
 - Numer seryjny i kod dostępu (Access Code / PIN) każdej drukarki
+
+### Instalacja
+
+Pobierz `BambuBar-Setup-Windows-x64.exe` z najnowszego wydania GitHub. Instalator działa
+dla bieżącego użytkownika bez uprawnień administratora, uruchamia BambuBar po instalacji i
+włącza start aplikacji przy logowaniu do Windows. Dodaje również skrót w menu Start oraz
+standardowy deinstalator. Wariant przenośny ZIP pozostaje dostępny jako alternatywa.
 
 ### Budowanie i uruchamianie
 

--- a/windows/installer/BambuBar.iss
+++ b/windows/installer/BambuBar.iss
@@ -1,0 +1,53 @@
+#define MyAppName "BambuBar"
+#define MyAppVersion "0.1.18"
+#define MyAppPublisher "Kamil Grzegorczyk"
+#define MyAppURL "https://github.com/parametryczny/BambuBar"
+#define MyAppExeName "BambuBar.exe"
+
+[Setup]
+AppId={{D83CD1A0-DC31-4A57-A152-8B7EE75046F1}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion} Windows Beta
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases
+DefaultDirName={localappdata}\Programs\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+OutputDir=..\installer-output
+OutputBaseFilename=BambuBar-Setup-Windows-x64
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+CloseApplications=yes
+RestartApplications=no
+UninstallDisplayName={#MyAppName}
+UninstallDisplayIcon={app}\{#MyAppExeName}
+VersionInfoVersion=0.1.18.0
+VersionInfoCompany={#MyAppPublisher}
+VersionInfoDescription=BambuBar Windows Beta Installer
+VersionInfoProductName={#MyAppName}
+VersionInfoProductVersion={#MyAppVersion}
+VersionInfoCopyright=Copyright (C) 2026 Kamil Grzegorczyk
+LicenseFile=..\..\LICENSE
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "polish"; MessagesFile: "compiler:Languages\Polish.isl"
+
+[Files]
+Source: "..\publish\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"
+
+[Registry]
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "BambuBar"; ValueData: """{app}\{#MyAppExeName}"""; Flags: uninsdeletevalue
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; WorkingDir: "{app}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
- add a per-user Inno Setup installer for the Windows beta
- install BambuBar in LocalAppData without administrator privileges
- launch BambuBar after installation and automatically at Windows sign-in
- add a Start menu shortcut and standard uninstaller
- keep the portable ZIP as an alternative

## Verification
- Windows build and Bambu Studio configuration import passed
- self-contained application and installer built successfully
- CI verified silent installation, autostart registration, uninstallation, and autostart cleanup