### PR TITLE
Add Windows notification settings

### DIFF
--- a/windows/BambuBar.Windows/Services/PrinterStore.cs
+++ b/windows/BambuBar.Windows/Services/PrinterStore.cs
@@ -365,11 +365,11 @@ public sealed class PrinterStore
     private void NotifyChanges(SavedPrinter printer, PrinterTelemetry? previous, PrinterTelemetry current)
     {
         bool pl = AppSettings.Polish;
-        if (current.State == PrinterState.Finished && previous?.State != PrinterState.Finished)
+        if (AppSettings.NotifyPrintFinished && current.State == PrinterState.Finished && previous?.State != PrinterState.Finished)
             NotificationService.Post(AppSettings.Text("Druk zakończony", "Print finished"),
                 current.JobName ?? AppSettings.Text("Zadanie zostało ukończone.", "The job has completed."), printer.Name);
 
-        if (current.State == PrinterState.Error && (previous?.State != PrinterState.Error || !SequenceEqual(previous?.HmsCodes, current.HmsCodes)))
+        if (AppSettings.NotifyPrinterError && current.State == PrinterState.Error && (previous?.State != PrinterState.Error || !SequenceEqual(previous?.HmsCodes, current.HmsCodes)))
         {
             string description = HmsResolver.Description(current.HmsCodes, printer.Serial, pl)
                 ?? (current.ErrorCode != 0
@@ -377,7 +377,7 @@ public sealed class PrinterStore
                     : AppSettings.Text("Drukarka zgłosiła błąd.", "The printer reported an error."));
             NotificationService.Post(AppSettings.Text("Błąd drukarki", "Printer error"), description, printer.Name);
         }
-        else if (current.State == PrinterState.Paused && previous?.State != PrinterState.Paused)
+        else if (AppSettings.NotifyPrintPaused && current.State == PrinterState.Paused && previous?.State != PrinterState.Paused)
         {
             NotificationService.Post(AppSettings.Text("Druk wstrzymany", "Print paused"),
                 current.JobName ?? AppSettings.Text("Drukarka oczekuje na działanie.", "The printer needs attention."), printer.Name);
@@ -385,11 +385,11 @@ public sealed class PrinterStore
 
         var previousLow = new HashSet<string>((previous?.AmsSlots ?? new()).Where(s => (s.RemainingPercent ?? 100) <= 15).Select(s => s.Id));
         var newLow = current.AmsSlots.Where(s => (s.RemainingPercent ?? 100) <= 15 && !previousLow.Contains(s.Id)).ToList();
-        if (newLow.FirstOrDefault() is { } slot)
+        if (AppSettings.NotifyLowFilament && newLow.FirstOrDefault() is { } slot)
             NotificationService.Post(AppSettings.Text("Niski poziom filamentu", "Low filament"),
                 $"{slot.Label} • {slot.Material} • {slot.RemainingPercent ?? 0}%", printer.Name);
 
-        if (IsHumidityHigh(current.AmsHumidity) && !IsHumidityHigh(previous?.AmsHumidity))
+        if (AppSettings.NotifyHighAmsHumidity && IsHumidityHigh(current.AmsHumidity) && !IsHumidityHigh(previous?.AmsHumidity))
             NotificationService.Post(AppSettings.Text("Wysoka wilgotność AMS", "High AMS humidity"),
                 AppSettings.Text("Sprawdź lub osusz pochłaniacz wilgoci.", "Check or dry the desiccant."), printer.Name);
     }

--- a/windows/BambuBar.Windows/Services/Storage.cs
+++ b/windows/BambuBar.Windows/Services/Storage.cs
@@ -120,6 +120,36 @@ public static class AppSettings
         set => Defaults.SetBool("dashboard-compact-mode", value);
     }
 
+    public static bool NotifyPrintFinished
+    {
+        get => Defaults.GetBool("notifications-print-finished", true);
+        set => Defaults.SetBool("notifications-print-finished", value);
+    }
+
+    public static bool NotifyPrinterError
+    {
+        get => Defaults.GetBool("notifications-printer-error", true);
+        set => Defaults.SetBool("notifications-printer-error", value);
+    }
+
+    public static bool NotifyPrintPaused
+    {
+        get => Defaults.GetBool("notifications-print-paused", true);
+        set => Defaults.SetBool("notifications-print-paused", value);
+    }
+
+    public static bool NotifyLowFilament
+    {
+        get => Defaults.GetBool("notifications-low-filament", true);
+        set => Defaults.SetBool("notifications-low-filament", value);
+    }
+
+    public static bool NotifyHighAmsHumidity
+    {
+        get => Defaults.GetBool("notifications-high-ams-humidity", true);
+        set => Defaults.SetBool("notifications-high-ams-humidity", value);
+    }
+
     public static string Text(string polish, string english) => Polish ? polish : english;
 
     private static string DefaultLanguage()

--- a/windows/BambuBar.Windows/UI/SettingsWindow.xaml
+++ b/windows/BambuBar.Windows/UI/SettingsWindow.xaml
@@ -1,0 +1,33 @@
+<Window x:Class="BambuBar.UI.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="BambuBar" Width="420" Height="390"
+        WindowStartupLocation="CenterScreen"
+        Background="#FF1C1C1E" Foreground="#FFF5F5F7"
+        FontFamily="Segoe UI" ResizeMode="NoResize" ShowInTaskbar="True">
+    <Grid Margin="22">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock x:Name="Heading" FontSize="20" FontWeight="SemiBold"/>
+        <TextBlock Grid.Row="1" x:Name="SectionHeading" Margin="0,22,0,10"
+                   FontSize="13" FontWeight="SemiBold" Foreground="#FFAEAEB2"/>
+
+        <Border Grid.Row="2" Background="#FF2C2C2E" CornerRadius="12" Padding="16,12">
+            <StackPanel>
+                <CheckBox x:Name="PrintFinishedCheckBox" Margin="0,7" FontSize="13"/>
+                <CheckBox x:Name="PrinterErrorCheckBox" Margin="0,7" FontSize="13"/>
+                <CheckBox x:Name="PrintPausedCheckBox" Margin="0,7" FontSize="13"/>
+                <CheckBox x:Name="LowFilamentCheckBox" Margin="0,7" FontSize="13"/>
+                <CheckBox x:Name="HighHumidityCheckBox" Margin="0,7" FontSize="13"/>
+            </StackPanel>
+        </Border>
+
+        <Button Grid.Row="3" x:Name="CloseButton" Width="104" Height="32"
+                HorizontalAlignment="Right" Margin="0,18,0,0" IsDefault="True"/>
+    </Grid>
+</Window>

--- a/windows/BambuBar.Windows/UI/SettingsWindow.xaml.cs
+++ b/windows/BambuBar.Windows/UI/SettingsWindow.xaml.cs
@@ -1,0 +1,43 @@
+using System.Windows;
+using BambuBar.Services;
+
+namespace BambuBar.UI;
+
+public partial class SettingsWindow : Window
+{
+    public SettingsWindow()
+    {
+        InitializeComponent();
+        ApplyLanguage();
+        LoadSettings();
+
+        PrintFinishedCheckBox.Click += (_, _) => AppSettings.NotifyPrintFinished = PrintFinishedCheckBox.IsChecked == true;
+        PrinterErrorCheckBox.Click += (_, _) => AppSettings.NotifyPrinterError = PrinterErrorCheckBox.IsChecked == true;
+        PrintPausedCheckBox.Click += (_, _) => AppSettings.NotifyPrintPaused = PrintPausedCheckBox.IsChecked == true;
+        LowFilamentCheckBox.Click += (_, _) => AppSettings.NotifyLowFilament = LowFilamentCheckBox.IsChecked == true;
+        HighHumidityCheckBox.Click += (_, _) => AppSettings.NotifyHighAmsHumidity = HighHumidityCheckBox.IsChecked == true;
+        CloseButton.Click += (_, _) => Close();
+    }
+
+    private void ApplyLanguage()
+    {
+        Title = AppSettings.Text("Ustawienia BambuBar", "BambuBar Settings");
+        Heading.Text = AppSettings.Text("Ustawienia", "Settings");
+        SectionHeading.Text = AppSettings.Text("POWIADOMIENIA", "NOTIFICATIONS");
+        PrintFinishedCheckBox.Content = AppSettings.Text("Druk zakończony", "Print finished");
+        PrinterErrorCheckBox.Content = AppSettings.Text("Błąd drukarki", "Printer error");
+        PrintPausedCheckBox.Content = AppSettings.Text("Druk wstrzymany", "Print paused");
+        LowFilamentCheckBox.Content = AppSettings.Text("Niski poziom filamentu", "Low filament");
+        HighHumidityCheckBox.Content = AppSettings.Text("Wysoka wilgotność AMS", "High AMS humidity");
+        CloseButton.Content = AppSettings.Text("Zamknij", "Close");
+    }
+
+    private void LoadSettings()
+    {
+        PrintFinishedCheckBox.IsChecked = AppSettings.NotifyPrintFinished;
+        PrinterErrorCheckBox.IsChecked = AppSettings.NotifyPrinterError;
+        PrintPausedCheckBox.IsChecked = AppSettings.NotifyPrintPaused;
+        LowFilamentCheckBox.IsChecked = AppSettings.NotifyLowFilament;
+        HighHumidityCheckBox.IsChecked = AppSettings.NotifyHighAmsHumidity;
+    }
+}

--- a/windows/BambuBar.Windows/UI/TrayIcon.cs
+++ b/windows/BambuBar.Windows/UI/TrayIcon.cs
@@ -12,6 +12,7 @@ public sealed class TrayIcon : IDisposable
     private readonly PrinterStore _store;
     private readonly NotifyIcon _notifyIcon;
     private DashboardWindow? _dashboard;
+    private SettingsWindow? _settings;
 
     public TrayIcon(PrinterStore store)
     {
@@ -38,6 +39,8 @@ public sealed class TrayIcon : IDisposable
         menu.Items.Add(new ToolStripMenuItem(AppSettings.Text("Szukaj drukarek…", "Scan for printers…"), null, (_, _) => { ShowDashboard(); _store.Scan(); }));
         menu.Items.Add(new ToolStripMenuItem(AppSettings.Text("Połącz ponownie", "Reconnect all"), null, (_, _) => _store.ReconnectAll()));
         menu.Items.Add(new ToolStripSeparator());
+
+        menu.Items.Add(new ToolStripMenuItem(AppSettings.Text("Ustawienia…", "Settings…"), null, (_, _) => ShowSettings()));
 
         var language = new ToolStripMenuItem(AppSettings.Text("Język: Polski", "Language: English"));
         language.Click += (_, _) => { AppSettings.Polish = !AppSettings.Polish; RebuildMenu(); };
@@ -74,6 +77,18 @@ public sealed class TrayIcon : IDisposable
         _dashboard.Show();
         _dashboard.Activate();
         _dashboard.WindowState = System.Windows.WindowState.Normal;
+    }
+
+    private void ShowSettings()
+    {
+        if (_settings is null)
+        {
+            _settings = new SettingsWindow();
+            _settings.Closed += (_, _) => _settings = null;
+        }
+        _settings.Show();
+        _settings.Activate();
+        _settings.WindowState = System.Windows.WindowState.Normal;
     }
 
     public void ShowNotification(string title, string body, string? subtitle)


### PR DESCRIPTION
## Co zmieniono

- dodano okno „Ustawienia…” dostępne z menu ikony BambuBar w zasobniku Windows
- dodano osobny checkbox dla zakończenia druku, błędu drukarki, wstrzymania druku, niskiego poziomu filamentu i wysokiej wilgotności AMS
- ustawienia są zapisywane lokalnie i działają od razu
- wszystkie typy powiadomień pozostają domyślnie włączone dla dotychczasowych użytkowników
- dodano polskie i angielskie etykiety

## Po co

Użytkownik może zdecydować, które zdarzenia mają wyświetlać powiadomienia systemowe, bez wyłączania wszystkich komunikatów BambuBar w ustawieniach Windows.

## Weryfikacja

- `git diff --check`
- pełna kompilacja i testy Windows zostaną wykonane przez GitHub Actions
- zmiany macOS obecne lokalnie nie zostały dołączone do commita
