### PR TITLE
Release BambuBar 0.1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 ## Downloads / Pobieranie
 
-- [macOS Local](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-0.1.18-macOS-Local.zip)
-- [macOS Keychain](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-0.1.18-macOS-Keychain.zip)
-- [Windows x64 installer — beta, recommended](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-Setup-Windows-x64.exe)
-- [Windows x64 portable ZIP — beta](https://github.com/parametryczny/BambuBar/releases/download/v0.1.18/BambuBar-Windows-x64.zip)
+- [macOS Local](https://github.com/parametryczny/BambuBar/releases/download/v0.1.19/BambuBar-0.1.19-macOS-Local.zip)
+- [macOS Keychain](https://github.com/parametryczny/BambuBar/releases/download/v0.1.19/BambuBar-0.1.19-macOS-Keychain.zip)
+- [Windows x64 installer — beta, recommended](https://github.com/parametryczny/BambuBar/releases/download/v0.1.19/BambuBar-Setup-Windows-x64.exe)
+- [Windows x64 portable ZIP — beta](https://github.com/parametryczny/BambuBar/releases/download/v0.1.19/BambuBar-Windows-x64.zip)
 
 The Windows installer starts BambuBar after installation and enables launch at sign-in. Neither Windows download requires a separate .NET installation. / Instalator Windows uruchamia BambuBar po instalacji i włącza start przy logowaniu. Żaden wariant Windows nie wymaga osobnej instalacji .NET.
 
@@ -34,7 +34,7 @@ A compact, MIT-licensed macOS menu bar and Windows system-tray monitor for Bambu
 
 ### Latest changes
 
-Version 0.1.18 adds the first self-contained Windows x64 beta alongside the macOS Local and Keychain builds.
+Version 0.1.19 adds configurable notifications, improved telemetry handling and automatic update checks.
 
 [Read the full changelog](CHANGELOG.md)
 
@@ -134,7 +134,7 @@ Kompaktowy monitor drukarek 3D Bambu Lab dla paska menu macOS i zasobnika system
 
 ### Najnowsze zmiany
 
-Wersja 0.1.18 dodaje pierwszą samodzielną betę Windows x64 obok wariantów macOS Local i Keychain.
+Wersja 0.1.19 dodaje konfigurowalne powiadomienia, ulepszoną obsługę telemetrii i automatyczne sprawdzanie aktualizacji.
 
 [Zobacz pełny changelog](CHANGELOG.md)
 

--- a/Sources/BambuBar/Views/SettingsWindowController.swift
+++ b/Sources/BambuBar/Views/SettingsWindowController.swift
@@ -188,7 +188,7 @@ final class SettingsWindowController: NSWindowController {
         notifyLowFilamentCheck.state = settings.notifyLowFilament ? .on : .off
         notifyHumidityCheck.state = settings.notifyHumidity ? .on : .off
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-            ?? "0.1.17"
+            ?? "0.1.19"
         versionLabel.stringValue = settings.text("Wersja \(version)", "Version \(version)") + " • \(AccessCodeStore.modeName)"
         supportButton.title = settings.text("Wesprzyj projekt", "Support the project")
         closeButton.title = settings.text("Gotowe", "Done")

--- a/windows/BambuBar.Windows/BambuBar.Windows.csproj
+++ b/windows/BambuBar.Windows/BambuBar.Windows.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>BambuBar</AssemblyName>
     <RootNamespace>BambuBar</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Version>0.1.18</Version>
+    <Version>0.1.19</Version>
     <Product>BambuBar</Product>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/windows/BambuBar.Windows/Models/PrinterModels.cs
+++ b/windows/BambuBar.Windows/Models/PrinterModels.cs
@@ -114,4 +114,3 @@ public sealed class DiscoveredPrinter
     public string Model { get; set; } = "Bambu Lab";
     public string Host { get; set; } = "";
 }
-

--- a/windows/installer/BambuBar.iss
+++ b/windows/installer/BambuBar.iss
@@ -1,5 +1,5 @@
 #define MyAppName "BambuBar"
-#define MyAppVersion "0.1.18"
+#define MyAppVersion "0.1.19"
 #define MyAppPublisher "Kamil Grzegorczyk"
 #define MyAppURL "https://github.com/parametryczny/BambuBar"
 #define MyAppExeName "BambuBar.exe"
@@ -28,7 +28,7 @@ CloseApplications=yes
 RestartApplications=no
 UninstallDisplayName={#MyAppName}
 UninstallDisplayIcon={app}\{#MyAppExeName}
-VersionInfoVersion=0.1.18.0
+VersionInfoVersion=0.1.19.0
 VersionInfoCompany={#MyAppPublisher}
 VersionInfoDescription=BambuBar Windows Beta Installer
 VersionInfoProductName={#MyAppName}


### PR DESCRIPTION
## Wydanie 0.1.19

- dodaje konfigurowalne typy powiadomień na macOS i Windows
- przełącza macOS na natywne powiadomienia i dodaje sprawdzanie aktualizacji
- dopasowuje wysokość panelu macOS do liczby drukarek
- zachowuje dane AMS podczas częściowych aktualizacji telemetrii
- wykrywa czujnik temperatury komory z rzeczywistej telemetrii
- aktualizuje wersje aplikacji, instalatora i linki pobierania do 0.1.19

## Weryfikacja

- `git diff --check`
- 22 testy Swift w 3 zestawach — wszystkie przeszły
- kompilacja Windows, test importu Bambu Studio oraz test instalatora zostaną wykonane przez GitHub Actions

Grafiki promocyjne obecne lokalnie nie są częścią tego PR.
