### PR TITLE
Adding custom CIDR for printers discovery

### DIFF
--- a/windows/BambuBar.Windows/Services/Storage.cs
+++ b/windows/BambuBar.Windows/Services/Storage.cs
@@ -164,6 +164,12 @@ public static class AppSettings
         set => Defaults.SetBool("notifications-high-ams-humidity", value);
     }
 
+    public static string SubnetScanTargets
+    {
+        get => Defaults.GetString("discovery-subnet-targets") ?? string.Empty;
+        set => Defaults.SetString("discovery-subnet-targets", value.Trim());
+    }
+
     public static string Text(string polish, string english) => Polish ? polish : english;
 
     private static string DefaultLanguage()

--- a/windows/BambuBar.Windows/Services/SubnetDiscovery.cs
+++ b/windows/BambuBar.Windows/Services/SubnetDiscovery.cs
@@ -13,15 +13,12 @@ namespace BambuBar.Services;
 /// </summary>
 public sealed class SubnetDiscovery
 {
+    private const int MaxCustomHosts = 4096;
+
     public async Task<List<DiscoveredPrinter>> ScanAsync()
     {
-        var prefixes = LocalIPv4Prefixes();
-        if (prefixes.Count == 0) return new List<DiscoveredPrinter>();
-
-        var hosts = prefixes
-            .SelectMany(prefix => Enumerable.Range(1, 254).Select(i => $"{prefix}.{i}"))
-            .Distinct()
-            .ToList();
+        var hosts = HostsToScan();
+        if (hosts.Count == 0) return new List<DiscoveredPrinter>();
 
         var found = new Dictionary<string, DiscoveredPrinter>();
         var gate = new object();
@@ -44,6 +41,164 @@ public sealed class SubnetDiscovery
             .OrderBy(p => p.Host, new HostComparer())
             .ToList();
     }
+
+    internal static bool IsValidTargetExpression(string input)
+    {
+        foreach (var token in ParseTokens(input))
+        {
+            if (token.Contains('/'))
+            {
+                if (!TryParseCidr(token, out _, out _)) return false;
+                continue;
+            }
+            if (token.Contains('-'))
+            {
+                if (!TryParseRange(token, out _, out _)) return false;
+                continue;
+            }
+            if (!TryParseIPv4(token, out _)) return false;
+        }
+        return true;
+    }
+
+    private static List<string> HostsToScan()
+    {
+        var prefixes = LocalIPv4Prefixes();
+        var automaticHosts = prefixes
+            .SelectMany(prefix => Enumerable.Range(1, 254).Select(i => $"{prefix}.{i}"))
+            .Distinct()
+            .ToList();
+
+        var configuredTargets = AppSettings.SubnetScanTargets;
+        if (string.IsNullOrWhiteSpace(configuredTargets)
+            || !TryExpandTargets(configuredTargets, MaxCustomHosts, out var configured)
+            || configured.Count == 0)
+        {
+            return automaticHosts;
+        }
+
+        return automaticHosts
+            .Concat(configured)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static bool TryExpandTargets(string input, int maxHosts, out List<string> hosts)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var token in ParseTokens(input))
+        {
+            if (token.Contains('/'))
+            {
+                if (!TryParseCidr(token, out var network, out var prefixLength))
+                {
+                    hosts = new List<string>();
+                    return false;
+                }
+                AddCidrHosts(set, network, prefixLength, maxHosts);
+            }
+            else if (token.Contains('-'))
+            {
+                if (!TryParseRange(token, out var start, out var end))
+                {
+                    hosts = new List<string>();
+                    return false;
+                }
+                AddRangeHosts(set, start, end, maxHosts);
+            }
+            else
+            {
+                if (!TryParseIPv4(token, out var single))
+                {
+                    hosts = new List<string>();
+                    return false;
+                }
+                if (set.Count < maxHosts) set.Add(ToIPv4String(single));
+            }
+
+            if (set.Count >= maxHosts) break;
+        }
+
+        hosts = set.ToList();
+        hosts.Sort(new HostComparer());
+        return true;
+    }
+
+    private static IEnumerable<string> ParseTokens(string input)
+        => input.Split(new[] { ',', ';', '\n', '\r', '\t', ' ' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static bool TryParseCidr(string token, out uint network, out int prefixLength)
+    {
+        network = 0;
+        prefixLength = 0;
+
+        var parts = token.Split('/', StringSplitOptions.TrimEntries);
+        if (parts.Length != 2) return false;
+        if (!TryParseIPv4(parts[0], out var address)) return false;
+        if (!int.TryParse(parts[1], out prefixLength) || prefixLength < 0 || prefixLength > 32) return false;
+
+        uint mask = prefixLength == 0 ? 0U : uint.MaxValue << (32 - prefixLength);
+        network = address & mask;
+        return true;
+    }
+
+    private static bool TryParseRange(string token, out uint start, out uint end)
+    {
+        start = 0;
+        end = 0;
+
+        var parts = token.Split('-', StringSplitOptions.TrimEntries);
+        if (parts.Length != 2) return false;
+        if (!TryParseIPv4(parts[0], out start)) return false;
+        if (!TryParseIPv4(parts[1], out end)) return false;
+        if (start > end) return false;
+        return true;
+    }
+
+    private static void AddCidrHosts(HashSet<string> set, uint network, int prefixLength, int maxHosts)
+    {
+        uint hostBits = (uint)(32 - prefixLength);
+        uint size = hostBits == 32 ? uint.MaxValue : (1U << (int)hostBits);
+        if (prefixLength == 0) size = uint.MaxValue;
+
+        uint first = network;
+        uint last = size == uint.MaxValue ? uint.MaxValue : network + size - 1;
+
+        if (prefixLength <= 30 && size >= 2)
+        {
+            first = network + 1;
+            last = network + size - 2;
+        }
+
+        AddRangeHosts(set, first, last, maxHosts);
+    }
+
+    private static void AddRangeHosts(HashSet<string> set, uint start, uint end, int maxHosts)
+    {
+        if (end < start) return;
+        for (uint value = start; value <= end; value++)
+        {
+            if (set.Count >= maxHosts) return;
+            set.Add(ToIPv4String(value));
+            if (value == uint.MaxValue) return;
+        }
+    }
+
+    private static bool TryParseIPv4(string text, out uint value)
+    {
+        value = 0;
+        if (!IPAddress.TryParse(text, out var ip)) return false;
+        var bytes = ip.GetAddressBytes();
+        if (bytes.Length != 4) return false;
+        value = ((uint)bytes[0] << 24)
+              | ((uint)bytes[1] << 16)
+              | ((uint)bytes[2] << 8)
+              | bytes[3];
+        return true;
+    }
+
+    private static string ToIPv4String(uint value)
+        => $"{(value >> 24) & 255}.{(value >> 16) & 255}.{(value >> 8) & 255}.{value & 255}";
 
     private static async Task<DiscoveredPrinter?> ProbeAsync(string host)
     {

--- a/windows/BambuBar.Windows/UI/SettingsWindow.xaml
+++ b/windows/BambuBar.Windows/UI/SettingsWindow.xaml
@@ -84,6 +84,21 @@
                         <Button Grid.Column="1" x:Name="LanguageButton" MinWidth="96"/>
                     </Grid>
                     <CheckBox x:Name="StartupCheckBox" Margin="0,10,0,4"/>
+                    <Border Height="1" Background="#18FFFFFF" Margin="0,10,0,8"/>
+                    <TextBlock x:Name="SubnetTargetsLabel" FontSize="13" Margin="0,2,0,4"/>
+                    <TextBox x:Name="SubnetTargetsBox"
+                             FontSize="13"
+                             Padding="8,5"
+                             Background="#FF2C2C2E"
+                             Foreground="#FFF5F5F7"
+                             CaretBrush="#FFF5F5F7"
+                             BorderBrush="#33FFFFFF"
+                             BorderThickness="1"/>
+                    <TextBlock x:Name="SubnetTargetsHint"
+                               FontSize="11"
+                               Foreground="#FF9A9A9E"
+                               Margin="0,4,0,0"
+                               TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
 

--- a/windows/BambuBar.Windows/UI/SettingsWindow.xaml.cs
+++ b/windows/BambuBar.Windows/UI/SettingsWindow.xaml.cs
@@ -30,7 +30,28 @@ public partial class SettingsWindow : Window
         QuietHoursCheckBox.Click += (_, _) => { QuietHours.Enabled = QuietHoursCheckBox.IsChecked == true; QuietTimesRow.IsEnabled = QuietHoursCheckBox.IsChecked == true; };
         QuietStartBox.LostFocus += (_, _) => SaveQuietTimes();
         QuietEndBox.LostFocus += (_, _) => SaveQuietTimes();
+        SubnetTargetsBox.LostFocus += (_, _) => SaveSubnetTargets();
         CloseButton.Click += (_, _) => Close();
+    }
+
+    private void SaveSubnetTargets()
+    {
+        var input = (SubnetTargetsBox.Text ?? string.Empty).Trim();
+        if (input.Length == 0)
+        {
+            AppSettings.SubnetScanTargets = string.Empty;
+            return;
+        }
+
+        if (BambuBar.Services.SubnetDiscovery.IsValidTargetExpression(input))
+        {
+            AppSettings.SubnetScanTargets = input;
+            SubnetTargetsBox.Text = input;
+        }
+        else
+        {
+            SubnetTargetsBox.Text = AppSettings.SubnetScanTargets;
+        }
     }
 
     private void SaveQuietTimes()
@@ -62,6 +83,10 @@ public partial class SettingsWindow : Window
         LanguageLabel.Text = AppSettings.Text("Język", "Language");
         LanguageButton.Content = AppSettings.Polish ? "Polski" : "English";
         StartupCheckBox.Content = AppSettings.Text("Uruchamiaj z Windows", "Start with Windows");
+        SubnetTargetsLabel.Text = AppSettings.Text("Dodatkowe zakresy do skanowania", "Additional scan ranges");
+        SubnetTargetsHint.Text = AppSettings.Text(
+            "Podane zakresy są skanowane dodatkowo. Przykład: 100.64.10.0/24, 192.168.1.20-192.168.1.60",
+            "Entered ranges are scanned additionally. Example: 100.64.10.0/24, 192.168.1.20-192.168.1.60");
 
         NotificationsHeading.Text = AppSettings.Text("POWIADOMIENIA", "NOTIFICATIONS");
         PrintFinishedCheckBox.Content = AppSettings.Text("Druk zakończony", "Print finished");
@@ -92,6 +117,7 @@ public partial class SettingsWindow : Window
         QuietStartBox.Text = MinutesToText(QuietHours.StartMinutes);
         QuietEndBox.Text = MinutesToText(QuietHours.EndMinutes);
         QuietTimesRow.IsEnabled = QuietHours.Enabled;
+        SubnetTargetsBox.Text = AppSettings.SubnetScanTargets;
     }
 
     private async Task CheckUpdatesAsync()


### PR DESCRIPTION
I have few printers. Most of them are localy accesible in my local network, but one of them are external one and i used Tailscale VPN to connect to it. I figured out that M-SEARCH didnt work for your Autodiscovery in /24 subnet.
So i implemented additional setting for providing additional CIDR or IP/IP range to scan during autodiscovery.
With that implementation i builded whole solution and now it works perfectly via Tailscale!

Feel free to just cancel this PR and make your own implementation ;)